### PR TITLE
Send document context to embed iframe via postMessage

### DIFF
--- a/src/components/LaminaFieldAction.tsx
+++ b/src/components/LaminaFieldAction.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { EditIcon } from '@sanity/icons';
 import { Button, Flex } from '@sanity/ui';
-import { useClient } from 'sanity';
+import { useClient, useFormValue } from 'sanity';
+import { setDocumentContext } from '../lib/documentContext.js';
 
 interface LaminaImageInputProps {
   value?: {
@@ -17,6 +18,23 @@ export function LaminaImageInput(props: LaminaImageInputProps) {
   const { value, renderDefault, ...rest } = props;
   const client = useClient({ apiVersion: '2024-01-01' });
   const [runUrl, setRunUrl] = useState<string | null>(null);
+
+  // Track document context for the embed iframe
+  const documentTitle = useFormValue(['title']) as string | undefined;
+  const documentId = useFormValue(['_id']) as string | undefined;
+  const documentType = useFormValue(['_type']) as string | undefined;
+
+  useEffect(() => {
+    if (documentId && documentType) {
+      setDocumentContext({
+        documentId,
+        documentType,
+        documentTitle: documentTitle ?? null,
+        fieldName: null,
+        fieldType: 'image',
+      });
+    }
+  }, [documentId, documentType, documentTitle]);
 
   const assetRef = value?.asset?._ref ?? null;
 

--- a/src/lib/documentContext.ts
+++ b/src/lib/documentContext.ts
@@ -1,0 +1,24 @@
+/**
+ * Lightweight store for tracking the last-viewed document context.
+ * Updated by LaminaImageInput and regenerateAction when they interact
+ * with a document. Read by LaminaTool to populate the lamina:context
+ * postMessage sent to the embed iframe.
+ */
+
+export interface DocumentContext {
+  documentId: string;
+  documentType: string;
+  documentTitle: string | null;
+  fieldName: string | null;
+  fieldType: 'image' | 'file' | null;
+}
+
+let lastContext: DocumentContext | null = null;
+
+export function setDocumentContext(ctx: DocumentContext): void {
+  lastContext = ctx;
+}
+
+export function getDocumentContext(): DocumentContext | null {
+  return lastContext;
+}

--- a/src/tool/LaminaTool.tsx
+++ b/src/tool/LaminaTool.tsx
@@ -17,6 +17,7 @@ import {
 import { LaunchIcon, ImageIcon, ResetIcon, SearchIcon } from '@sanity/icons';
 import { useClient } from 'sanity';
 import { useLamina } from '../lib/LaminaContext.js';
+import { getDocumentContext } from '../lib/documentContext.js';
 const LAMINA_ORIGIN = 'https://app.uselamina.ai';
 
 interface LaminaMessage {
@@ -337,14 +338,16 @@ export function LaminaTool() {
           : { type: 'lamina:auth' as const, token };
         iframe.contentWindow.postMessage(authPayload, baseUrl);
 
-        // Send document context (generic for standalone tool)
+        // Send document context from last-viewed document (if available)
+        const docCtx = getDocumentContext();
         iframe.contentWindow.postMessage(
           {
             type: 'lamina:context',
-            schemaType: null,
-            fieldType: null,
+            schemaType: docCtx?.documentType ?? null,
+            documentTitle: docCtx?.documentTitle ?? null,
+            fieldType: docCtx?.fieldType ?? null,
             brandProfileId: null,
-            suggestedModality: null,
+            suggestedModality: docCtx?.fieldType === 'file' ? 'video' : docCtx?.fieldType === 'image' ? 'image' : null,
           },
           baseUrl,
         );


### PR DESCRIPTION
## Summary

- `LaminaFieldAction.tsx` now tracks the current document (id, type, title) via `useFormValue` and stores it in a lightweight context store
- `LaminaTool.tsx` reads `getDocumentContext()` and includes it in the `lamina:context` postMessage sent after auth handshake
- New `src/lib/documentContext.ts` provides `setDocumentContext` / `getDocumentContext` for cross-component context sharing

This gives the embedded Lamina editor awareness of which Sanity document the user is working on.

Closes #18

## Test plan

- [ ] Open a document with an image field that has a Lamina-sourced asset
- [ ] Verify the "Edit in Lamina" button appears on the field
- [ ] Open the Lamina Studio Tool tab
- [ ] Confirm the iframe receives `lamina:context` with the document type and field info

🤖 Generated with [Claude Code](https://claude.com/claude-code)