### PR TITLE
App auto-routing: remember app selection per field type

### DIFF
--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -42,6 +42,7 @@ import type {
 } from '@uselamina/sdk';
 import { LaminaAuthError, LaminaRateLimitError } from '@uselamina/sdk';
 import { useLamina } from '../lib/LaminaContext.js';
+import { getRoutedAppId, saveRoutedAppId } from '../lib/appRouting.js';
 import type { GeneratedOutput, GenerationState } from '../types.js';
 
 const MODALITIES = [
@@ -508,8 +509,9 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   const [costEstimate, setCostEstimate] = useState<CostEstimate | null>(null);
   const [estimateLoading, setEstimateLoading] = useState(false);
 
-  // App picker state
-  const [selectedAppId, setSelectedAppId] = useState<string | null>(null);
+  // App picker state — auto-select from routing history
+  const routedAppId = getRoutedAppId(documentType, fieldName);
+  const [selectedAppId, setSelectedAppId] = useState<string | null>(routedAppId);
   const [selectedAppName, setSelectedAppName] = useState<string | null>(null);
   const [appPicker, setAppPicker] = useState<AppPickerState>({
     expanded: false,
@@ -911,6 +913,11 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         error: null,
         progress: 100,
       });
+
+      // Save app routing for future auto-selection
+      if (selectedAppId && outputs.length > 0) {
+        saveRoutedAppId(documentType, fieldName, selectedAppId);
+      }
     } catch (err) {
       if (abort.signal.aborted) return;
       const isTimeout =
@@ -924,7 +931,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         progress: null,
       }));
     }
-  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, client]);
+  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, documentType, fieldName, client]);
 
   // Proxy a CDN URL through transferAsset to avoid CORS issues
   const resolveAssetUrl = useCallback(

--- a/src/lib/appRouting.ts
+++ b/src/lib/appRouting.ts
@@ -1,0 +1,40 @@
+/**
+ * Remembers which Lamina app was last used for each document-type + field-name
+ * combination. Stores in localStorage so the selection persists per-browser.
+ */
+
+const PREFIX = 'lamina_app_routing_';
+
+export function getRoutedAppId(documentType?: string, fieldName?: string): string | null {
+  if (!documentType) return null;
+  const key = `${PREFIX}${documentType}_${fieldName ?? '_default'}`;
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function saveRoutedAppId(
+  documentType: string | undefined,
+  fieldName: string | undefined,
+  appId: string,
+): void {
+  if (!documentType) return;
+  const key = `${PREFIX}${documentType}_${fieldName ?? '_default'}`;
+  try {
+    localStorage.setItem(key, appId);
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+export function clearRoutedAppId(documentType?: string, fieldName?: string): void {
+  if (!documentType) return;
+  const key = `${PREFIX}${documentType}_${fieldName ?? '_default'}`;
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // localStorage unavailable
+  }
+}


### PR DESCRIPTION
Closes #28
Plugin-only (localStorage). Auto-selects previously used app for each documentType+fieldName.
🤖 Generated with [Claude Code](https://claude.com/claude-code)