### PR TITLE
Recently used prompts as suggestion chips

### DIFF
--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -43,6 +43,7 @@ import type {
 import { LaminaAuthError, LaminaRateLimitError } from '@uselamina/sdk';
 import { useLamina } from '../lib/LaminaContext.js';
 import { getRoutedAppId, saveRoutedAppId } from '../lib/appRouting.js';
+import { getRecentBriefs, saveRecentBrief } from '../lib/recentBriefs.js';
 import type { GeneratedOutput, GenerationState } from '../types.js';
 
 const MODALITIES = [
@@ -477,6 +478,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   });
 
   const suggestions = getSuggestions(documentType, assetType);
+  const recentBriefs = getRecentBriefs(documentType, fieldName);
 
   const [dialogTab, setDialogTab] = useState<'generate' | 'library'>('generate');
   const [brief, setBrief] = useState('');
@@ -914,9 +916,12 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         progress: 100,
       });
 
-      // Save app routing for future auto-selection
-      if (selectedAppId && outputs.length > 0) {
-        saveRoutedAppId(documentType, fieldName, selectedAppId);
+      // Save app routing and brief to recent history
+      if (outputs.length > 0) {
+        if (selectedAppId) {
+          saveRoutedAppId(documentType, fieldName, selectedAppId);
+        }
+        saveRecentBrief(documentType, fieldName, brief, selectedAppId ?? undefined);
       }
     } catch (err) {
       if (abort.signal.aborted) return;
@@ -1123,6 +1128,24 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
           {/* Brief input */}
           <Stack space={2}>
             <Label size={1}>Describe what you need</Label>
+            {!brief && isIdle && recentBriefs.length > 0 ? (
+              <Stack space={1}>
+                <Text size={0} muted weight="medium">Recently used</Text>
+                <Inline space={1}>
+                  {recentBriefs.map((r) => (
+                    <Button
+                      key={r.brief}
+                      text={r.brief.length > 40 ? `${r.brief.substring(0, 40)}...` : r.brief}
+                      mode="ghost"
+                      fontSize={0}
+                      padding={2}
+                      tone="primary"
+                      onClick={() => setBrief(r.brief)}
+                    />
+                  ))}
+                </Inline>
+              </Stack>
+            ) : null}
             {!brief && isIdle ? (
               <Inline space={1}>
                 {suggestions.map((s) => (

--- a/src/lib/recentBriefs.ts
+++ b/src/lib/recentBriefs.ts
@@ -1,0 +1,44 @@
+/**
+ * Stores the last few successful briefs per document-type + field-name.
+ * Used to show "Recently used" suggestion chips in the GenerateDialog.
+ */
+
+const PREFIX = 'lamina_recent_';
+const MAX_RECENT = 5;
+
+interface RecentBrief {
+  brief: string;
+  timestamp: number;
+  appId?: string;
+}
+
+export function getRecentBriefs(documentType?: string, fieldName?: string): RecentBrief[] {
+  const key = `${PREFIX}${documentType ?? '_any'}_${fieldName ?? '_default'}`;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    return JSON.parse(raw) as RecentBrief[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentBrief(
+  documentType: string | undefined,
+  fieldName: string | undefined,
+  brief: string,
+  appId?: string,
+): void {
+  if (!brief.trim()) return;
+  const key = `${PREFIX}${documentType ?? '_any'}_${fieldName ?? '_default'}`;
+  try {
+    const existing = getRecentBriefs(documentType, fieldName);
+    const updated = [
+      { brief: brief.trim(), timestamp: Date.now(), appId },
+      ...existing.filter((r) => r.brief !== brief.trim()),
+    ].slice(0, MAX_RECENT);
+    localStorage.setItem(key, JSON.stringify(updated));
+  } catch {
+    // localStorage unavailable
+  }
+}


### PR DESCRIPTION
Closes #30
Plugin-only (localStorage). Shows last 5 successful briefs per field type as 'Recently used' chips.
🤖 Generated with [Claude Code](https://claude.com/claude-code)