### PR TITLE
Auto-detect aspect ratio from field name

### DIFF
--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -45,6 +45,8 @@ import { LaminaAuthError, LaminaRateLimitError } from '@uselamina/sdk';
 import { useLamina } from '../lib/LaminaContext.js';
 import { getRoutedAppId, saveRoutedAppId } from '../lib/appRouting.js';
 import { getRecentBriefs, saveRecentBrief } from '../lib/recentBriefs.js';
+import { detectAspectRatio, ASPECT_RATIO_OPTIONS } from '../lib/aspectRatio.js';
+import type { LaminaAspectRatio } from '../lib/aspectRatio.js';
 import type { GeneratedOutput, GenerationState } from '../types.js';
 
 const MODALITIES = [
@@ -487,6 +489,12 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   const [briefPreFilled, setBriefPreFilled] = useState(false);
   const [modality, setModality] = useState('');
 
+  // -- Aspect ratio auto-detection --
+  const detectedRatio = detectAspectRatio(fieldName);
+  const [aspectRatioOverride, setAspectRatioOverride] = useState<LaminaAspectRatio | ''>('');
+  const effectiveAspectRatio: LaminaAspectRatio | null =
+    aspectRatioOverride || detectedRatio?.ratio || null;
+
   // Pre-fill brief on first render if we have context
   useEffect(() => {
     if (!briefPreFilled && suggestedBrief && !brief) {
@@ -802,7 +810,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         ...(fieldDescription ? { fieldPurpose: fieldDescription } : {}),
       };
 
-      const createParams: LaminaCreateParams = {
+      const createParams: LaminaCreateParams & { aspectRatio?: string; metadata?: Record<string, string> } = {
         brief: brief.trim(),
         modality: resolvedModality,
         ...(selectedAppId ? { appId: selectedAppId } : {}),
@@ -810,6 +818,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         ...(selectedCampaignId ? { campaignId: selectedCampaignId } : {}),
         ...(options.webhookUrl ? { webhookUrl: options.webhookUrl } : {}),
         ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+        ...(effectiveAspectRatio ? { aspectRatio: effectiveAspectRatio } : {}),
       };
 
       // Batch mode: run multiple content.create() calls in parallel for variants
@@ -958,7 +967,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         progress: null,
       }));
     }
-  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, client, documentType, documentTitle, fieldName, fieldDescription]);
+  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, effectiveAspectRatio, client, documentType, documentTitle, fieldName, fieldDescription]);
 
   // Proxy a CDN URL through transferAsset to avoid CORS issues
   const resolveAssetUrl = useCallback(
@@ -1296,6 +1305,29 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
                 </option>
               ))}
             </Select>
+          </Stack>
+
+          {/* Aspect ratio */}
+          <Stack space={2}>
+            <Label size={1}>Aspect ratio</Label>
+            <Select
+              value={aspectRatioOverride}
+              onChange={(e) =>
+                setAspectRatioOverride(e.currentTarget.value as LaminaAspectRatio | '')
+              }
+              disabled={state.status === 'generating'}
+            >
+              {ASPECT_RATIO_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </Select>
+            {!aspectRatioOverride && detectedRatio ? (
+              <Text size={0} muted>
+                Detected: {detectedRatio.label}
+              </Text>
+            ) : null}
           </Stack>
 
           {/* Brand profile selector */}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { LaminaTool } from './tool/LaminaTool.js';
 export { createRegenerateAction } from './actions/regenerateAction.js';
 export { useLamina, LaminaProvider } from './lib/LaminaContext.js';
 export { useLaminaAssets } from './lib/useLaminaAssets.js';
+export { detectAspectRatio, ASPECT_RATIO_OPTIONS } from './lib/aspectRatio.js';
 export { AssetPickerGrid } from './components/AssetPickerGrid.js';
 export type {
   AssetTypeFilter,
@@ -19,3 +20,4 @@ export type {
 } from './types.js';
 export type { UseLaminaAssetsOptions, UseLaminaAssetsResult } from './lib/useLaminaAssets.js';
 export type { AssetPickerGridProps } from './components/AssetPickerGrid.js';
+export type { LaminaAspectRatio, DetectedAspectRatio } from './lib/aspectRatio.js';

--- a/src/lib/aspectRatio.ts
+++ b/src/lib/aspectRatio.ts
@@ -1,0 +1,124 @@
+/**
+ * Aspect ratio detection from Sanity field names.
+ *
+ * Maps common field naming conventions (e.g. heroImage, ogImage) to the
+ * closest valid Lamina API aspect ratio value so generated assets match
+ * the intended placement without manual editor intervention.
+ */
+
+/** Valid aspect ratio values accepted by the Lamina content.create() API. */
+export type LaminaAspectRatio = '1:1' | '16:9' | '9:16' | '4:3' | '4:5' | 'auto';
+
+export const ASPECT_RATIO_OPTIONS: readonly { value: LaminaAspectRatio | ''; label: string }[] = [
+  { value: '', label: 'Auto-detect' },
+  { value: '1:1', label: '1:1 (Square)' },
+  { value: '16:9', label: '16:9 (Landscape)' },
+  { value: '9:16', label: '9:16 (Portrait)' },
+  { value: '4:3', label: '4:3 (Classic)' },
+  { value: '4:5', label: '4:5 (Vertical)' },
+  { value: 'auto', label: 'Auto (let Lamina decide)' },
+] as const;
+
+/**
+ * Field-name-to-raw-ratio mapping.  The ratio values here are the *ideal*
+ * dimensions for the field; they get mapped to the nearest valid API value
+ * via {@link closestApiRatio}.
+ */
+const FIELD_ASPECT_RATIOS: Record<string, string> = {
+  ogImage: '1200:630',
+  socialImage: '1200:630',
+  instagramPost: '1:1',
+  instagramStory: '9:16',
+  storyImage: '9:16',
+  heroImage: '16:9',
+  hero: '16:9',
+  banner: '16:9',
+  thumbnail: '1:1',
+  avatar: '1:1',
+  logo: '1:1',
+  poster: '4:5',
+  coverImage: '16:9',
+};
+
+/**
+ * Map an arbitrary width:height ratio string to the closest valid
+ * {@link LaminaAspectRatio}.
+ */
+function closestApiRatio(raw: string): LaminaAspectRatio {
+  const parts = raw.split(':');
+  if (parts.length !== 2) return 'auto';
+
+  const w = Number(parts[0]);
+  const h = Number(parts[1]);
+  if (!Number.isFinite(w) || !Number.isFinite(h) || h === 0) return 'auto';
+
+  const target = w / h;
+
+  const candidates: { ratio: LaminaAspectRatio; value: number }[] = [
+    { ratio: '1:1', value: 1 },
+    { ratio: '16:9', value: 16 / 9 },
+    { ratio: '9:16', value: 9 / 16 },
+    { ratio: '4:3', value: 4 / 3 },
+    { ratio: '4:5', value: 4 / 5 },
+  ];
+
+  let best = candidates[0]!;
+  let bestDist = Math.abs(target - best.value);
+
+  for (const c of candidates) {
+    const dist = Math.abs(target - c.value);
+    if (dist < bestDist) {
+      best = c;
+      bestDist = dist;
+    }
+  }
+
+  return best.ratio;
+}
+
+/**
+ * Friendly label for detected ratios, mapping field names to human-readable
+ * descriptions.
+ */
+const FIELD_LABELS: Record<string, string> = {
+  ogImage: 'OG image',
+  socialImage: 'social image',
+  instagramPost: 'Instagram post',
+  instagramStory: 'Instagram story',
+  storyImage: 'story image',
+  heroImage: 'hero image',
+  hero: 'hero',
+  banner: 'banner',
+  thumbnail: 'thumbnail',
+  avatar: 'avatar',
+  logo: 'logo',
+  poster: 'poster',
+  coverImage: 'cover image',
+};
+
+export interface DetectedAspectRatio {
+  ratio: LaminaAspectRatio;
+  /** Human-readable explanation, e.g. "16:9 (hero image)" */
+  label: string;
+}
+
+/**
+ * Detect the best aspect ratio for a given field name.
+ *
+ * @returns The detected ratio and a human-readable label, or `null` when
+ *          the field name is unknown or not provided.
+ */
+export function detectAspectRatio(fieldName?: string): DetectedAspectRatio | null {
+  if (!fieldName) return null;
+
+  const rawRatio = FIELD_ASPECT_RATIOS[fieldName];
+  if (!rawRatio) return null;
+
+  const ratio = closestApiRatio(rawRatio);
+  const fieldLabel = FIELD_LABELS[fieldName] ?? fieldName;
+
+  return {
+    ratio,
+    label: `${ratio} (${fieldLabel})`,
+  };
+}


### PR DESCRIPTION
Closes #27
Detects ratio from field name heuristics. Passes aspectRatio to content.create(). Editor can override via dropdown. Requires Lamina PR #820.
🤖 Generated with [Claude Code](https://claude.com/claude-code)