### PR TITLE
Output format presets via plugin config

### DIFF
--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -32,7 +32,7 @@ import type { AssetFromSource, AssetSourceComponentProps } from 'sanity';
 import { useFormValue } from 'sanity';
 import { useLaminaAssets } from '../lib/useLaminaAssets.js';
 import { AssetPickerGrid } from './AssetPickerGrid.js';
-import type { AssetTypeFilter, LaminaAsset } from '../types.js';
+import type { AssetTypeFilter, LaminaAsset, LaminaPreset } from '../types.js';
 import type {
   AppSummary as SdkAppSummary,
   CostEstimate,
@@ -54,6 +54,35 @@ const MODALITIES = [
   { value: 'image', label: 'Image' },
   { value: 'video', label: 'Video' },
 ] as const;
+
+/** Built-in presets for common field names. Custom presets override these. */
+const DEFAULT_PRESETS: Record<string, LaminaPreset> = {
+  ogImage: { aspectRatio: '16:9', modality: 'image' },
+  socialImage: { aspectRatio: '16:9', modality: 'image' },
+  storyImage: { aspectRatio: '9:16', modality: 'image' },
+  thumbnail: { aspectRatio: '1:1', modality: 'image' },
+  avatar: { aspectRatio: '1:1', modality: 'image' },
+};
+
+/**
+ * Resolve a preset for the current field.
+ * Custom presets from plugin config take precedence over built-in defaults.
+ * Returns `[presetName, preset]` or `null` if no match.
+ */
+function resolvePreset(
+  fieldName: string | undefined,
+  customPresets: Record<string, LaminaPreset> | undefined,
+): [string, LaminaPreset] | null {
+  if (!fieldName) return null;
+  // Custom presets override defaults
+  if (customPresets?.[fieldName]) {
+    return [fieldName, customPresets[fieldName]];
+  }
+  if (DEFAULT_PRESETS[fieldName]) {
+    return [fieldName, DEFAULT_PRESETS[fieldName]];
+  }
+  return null;
+}
 
 /** 30 minutes in milliseconds. */
 const GENERATION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -484,10 +513,15 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   const suggestions = getSuggestions(documentType, assetType);
   const recentBriefs = getRecentBriefs(documentType, fieldName);
 
+  // -- Preset resolution --
+  const presetMatch = resolvePreset(fieldName, options.presets);
+  const activePresetName = presetMatch?.[0] ?? null;
+  const activePreset = presetMatch?.[1] ?? null;
+
   const [dialogTab, setDialogTab] = useState<'generate' | 'library'>('generate');
   const [brief, setBrief] = useState('');
   const [briefPreFilled, setBriefPreFilled] = useState(false);
-  const [modality, setModality] = useState('');
+  const [modality, setModality] = useState(activePreset?.modality ?? '');
 
   // -- Aspect ratio auto-detection --
   const detectedRatio = detectAspectRatio(fieldName);
@@ -543,6 +577,13 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   // Batch generation state
   const [batchMode, setBatchMode] = useState(false);
   const [batchCount, setBatchCount] = useState(2);
+
+  // Auto-set app from preset on mount
+  useEffect(() => {
+    if (activePreset?.appId && !selectedAppId) {
+      setSelectedAppId(activePreset.appId);
+    }
+  }, [activePreset?.appId, selectedAppId]);
 
   // Library picker state
   const [libraryFilter, setLibraryFilter] = useState<AssetTypeFilter>(
@@ -813,6 +854,8 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
       const createParams: LaminaCreateParams & { aspectRatio?: string; metadata?: Record<string, string> } = {
         brief: brief.trim(),
         modality: resolvedModality,
+        ...(activePreset?.aspectRatio ? { aspectRatio: activePreset.aspectRatio } : {}),
+        ...(activePreset?.platform ? { platform: activePreset.platform } : {}),
         ...(selectedAppId ? { appId: selectedAppId } : {}),
         ...(selectedBrandId ? { brandProfileId: selectedBrandId } : {}),
         ...(selectedCampaignId ? { campaignId: selectedCampaignId } : {}),
@@ -967,7 +1010,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         progress: null,
       }));
     }
-  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, effectiveAspectRatio, client, documentType, documentTitle, fieldName, fieldDescription]);
+  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, effectiveAspectRatio, activePreset, client, documentType, documentTitle, fieldName, fieldDescription]);
 
   // Proxy a CDN URL through transferAsset to avoid CORS issues
   const resolveAssetUrl = useCallback(
@@ -1306,6 +1349,16 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
               ))}
             </Select>
           </Stack>
+
+          {/* Active preset indicator */}
+          {activePresetName ? (
+            <Card padding={2} radius={2} tone="positive" border>
+              <Text size={1} muted>
+                Preset: <strong>{activePresetName}</strong>
+                {activePreset?.aspectRatio ? ` (${activePreset.aspectRatio})` : ''}
+              </Text>
+            </Card>
+          ) : null}
 
           {/* Aspect ratio */}
           <Stack space={2}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type {
   LaminaAssetSourceMeta,
   LaminaOAuthConfig,
   LaminaPluginOptions,
+  LaminaPreset,
 } from './types.js';
 export type { UseLaminaAssetsOptions, UseLaminaAssetsResult } from './lib/useLaminaAssets.js';
 export type { AssetPickerGridProps } from './components/AssetPickerGrid.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,18 @@ export interface LaminaOAuthConfig {
   storageKey?: string;
 }
 
+/** Output format preset that maps a field name to generation parameters. */
+export interface LaminaPreset {
+  /** Aspect ratio hint passed to the generation API (e.g. '16:9', '1:1'). */
+  aspectRatio?: string;
+  /** Modality override (e.g. 'image', 'video'). */
+  modality?: string;
+  /** Target platform hint (e.g. 'instagram', 'twitter'). */
+  platform?: string;
+  /** Pin a specific Lamina app for this field. */
+  appId?: string;
+}
+
 export interface LaminaPluginOptions {
   /** Lamina API key (team-level auth). Falls back to per-user OAuth if not set. */
   apiKey?: string;
@@ -39,6 +51,14 @@ export interface LaminaPluginOptions {
    * @default true
    */
   enableDocumentAction?: boolean;
+  /**
+   * Output format presets mapping field names to generation parameters.
+   * Keys are matched against the schema field name (e.g. 'ogImage', 'thumbnail').
+   * Custom presets override the built-in defaults.
+   *
+   * Built-in defaults: ogImage, socialImage, storyImage, thumbnail, avatar.
+   */
+  presets?: Record<string, LaminaPreset>;
 }
 
 /** Metadata stored on Sanity asset documents for Lamina-generated assets. */


### PR DESCRIPTION
Closes #31
Adds presets option to LaminaPluginOptions. Built-in defaults for ogImage, thumbnail, etc. Custom presets override defaults. Requires Lamina PR #820.
🤖 Generated with [Claude Code](https://claude.com/claude-code)