### PR TITLE
Inline brief refinement alongside generated results

### DIFF
--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -1668,9 +1668,35 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
             </Card>
           ) : null}
 
-          {/* Results */}
+          {/* Results with side-by-side refinement */}
           {state.status === 'completed' && state.outputs.length > 0 && !feedbackState ? (
             <Stack space={3}>
+              {/* Refinement panel: brief + regenerate side by side with results */}
+              <Card padding={3} radius={2} border tone="transparent">
+                <Stack space={2}>
+                  <Label size={0}>Refine your brief and regenerate</Label>
+                  <Flex gap={2} align="flex-end">
+                    <Box style={{ flex: 1 }}>
+                      <TextArea
+                        value={brief}
+                        onChange={(e) => setBrief(e.currentTarget.value)}
+                        rows={2}
+                        fontSize={1}
+                      />
+                    </Box>
+                    <Button
+                      text="Regenerate"
+                      icon={ResetIcon}
+                      tone="primary"
+                      onClick={handleGenerate}
+                      disabled={!brief.trim()}
+                      fontSize={1}
+                      padding={3}
+                    />
+                  </Flex>
+                </Stack>
+              </Card>
+
               <Label size={1}>Generated assets</Label>
               <Grid columns={state.outputs.length > 1 ? 2 : 1} gap={3}>
                 {state.outputs.map((output) => (
@@ -1742,18 +1768,6 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
                   disabled={selecting}
                 />
               ) : null}
-
-              {/* Regenerate */}
-              <Inline space={2}>
-                <Button
-                  text="Regenerate"
-                  tone="default"
-                  icon={ResetIcon}
-                  mode="ghost"
-                  onClick={handleReset}
-                  fontSize={1}
-                />
-              </Inline>
             </Stack>
           ) : null}
         </Stack>


### PR DESCRIPTION
## Summary

When results are showing after generation, display the brief editor inline above the results grid with a "Regenerate" button. Editors can tweak their prompt and regenerate iteratively without resetting the view or losing context.

**Before:** Results shown -> click Regenerate -> entire dialog resets to empty brief -> retype everything
**After:** Results shown -> edit brief inline -> click Regenerate -> new results replace old ones

## Test plan

- [ ] Generate an image, see the refinement panel above results
- [ ] Edit the brief and click Regenerate — new results appear
- [ ] "Use this" still works on results
- [ ] Feedback flow still works after "Use this"

🤖 Generated with [Claude Code](https://claude.com/claude-code)