### PR TITLE
P1 UX improvements: cancel, retry, feedback, multi-asset picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-lamina",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Sanity Studio plugin for generating media assets with Lamina",
   "keywords": [
     "sanity",

--- a/src/actions/regenerateAction.tsx
+++ b/src/actions/regenerateAction.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
-import { ResetIcon } from '@sanity/icons';
+import { ResetIcon, LaunchIcon } from '@sanity/icons';
+import { Box, Button, Card, Flex, Stack, Text } from '@sanity/ui';
 import type {
   DocumentActionComponent,
   DocumentActionProps,
@@ -141,6 +142,14 @@ async function findLaminaAssets(
   return results;
 }
 
+/** Formats a field path for display (e.g. "heroImage" → "Hero Image"). */
+function formatFieldPath(path: string): string {
+  // Take the last segment for display
+  const segments = path.split('.');
+  const last = segments[segments.length - 1].replace(/\[\d+\]$/, '');
+  return last.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()).trim();
+}
+
 export function createRegenerateAction(): DocumentActionComponent {
   const RegenerateAction: DocumentActionComponent = (
     props: DocumentActionProps,
@@ -149,6 +158,7 @@ export function createRegenerateAction(): DocumentActionComponent {
     const client = useClient({ apiVersion: '2024-01-01' });
     const schema = useSchema();
     const [checking, setChecking] = useState(false);
+    const [pickerAssets, setPickerAssets] = useState<LaminaAssetRef[] | null>(null);
 
     const schemaType = schema.get(documentType);
     const canHaveAssets = schemaContainsAssetFields(schemaType);
@@ -158,13 +168,19 @@ export function createRegenerateAction(): DocumentActionComponent {
       setChecking(true);
       try {
         const laminaAssets = await findLaminaAssets(client, documentId);
-        if (laminaAssets.length > 0) {
+        if (laminaAssets.length === 1) {
           window.open(laminaAssets[0].runUrl, '_blank', 'noopener');
+        } else if (laminaAssets.length > 1) {
+          setPickerAssets(laminaAssets);
         }
       } finally {
         setChecking(false);
       }
     }, [client, documentId]);
+
+    const handleClosePicker = useCallback(() => {
+      setPickerAssets(null);
+    }, []);
 
     if (!canHaveAssets || !hasDocument) return null;
 
@@ -173,6 +189,54 @@ export function createRegenerateAction(): DocumentActionComponent {
       icon: ResetIcon,
       onHandle: handleClick,
       disabled: checking,
+      dialog: pickerAssets
+        ? {
+            type: 'dialog' as const,
+            header: 'Edit in Lamina',
+            onClose: handleClosePicker,
+            content: (
+              <Box padding={4}>
+                <Stack space={3}>
+                  <Text size={1} muted>
+                    This document has {pickerAssets.length} Lamina-generated assets.
+                    Choose which one to edit:
+                  </Text>
+                  {pickerAssets.map((asset) => (
+                    <Card
+                      key={`${asset.fieldPath}-${asset.runId}`}
+                      padding={3}
+                      radius={2}
+                      border
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => {
+                        window.open(asset.runUrl, '_blank', 'noopener');
+                        setPickerAssets(null);
+                      }}
+                    >
+                      <Flex align="center" justify="space-between">
+                        <Stack space={2}>
+                          <Text size={1} weight="medium">
+                            {formatFieldPath(asset.fieldPath)}
+                          </Text>
+                          <Text size={0} muted>
+                            {asset.fieldPath}
+                          </Text>
+                        </Stack>
+                        <Button
+                          icon={LaunchIcon}
+                          mode="ghost"
+                          fontSize={1}
+                          padding={2}
+                          title="Open in Lamina"
+                        />
+                      </Flex>
+                    </Card>
+                  ))}
+                </Stack>
+              </Box>
+            ),
+          }
+        : null,
     };
   };
 

--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -1185,21 +1185,16 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
     [feedbackState, client, finishAndClose],
   );
 
-  // Start the auto-close timer whenever feedback UI appears
+  // Clean up any lingering timer on unmount (no auto-dismiss — user must
+  // click a feedback button or "Skip" to proceed).
   useEffect(() => {
-    if (feedbackState && !feedbackState.submitted) {
-      feedbackTimerRef.current = setTimeout(() => {
-        finishAndClose();
-      }, 5000);
-      return () => {
-        if (feedbackTimerRef.current) {
-          clearTimeout(feedbackTimerRef.current);
-          feedbackTimerRef.current = null;
-        }
-      };
-    }
-    return undefined;
-  }, [feedbackState, finishAndClose]);
+    return () => {
+      if (feedbackTimerRef.current) {
+        clearTimeout(feedbackTimerRef.current);
+        feedbackTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const handleSelectOutput = useCallback(
     async (output: GeneratedOutput) => {
@@ -1760,7 +1755,21 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
           {/* Error */}
           {state.status === 'failed' && state.error ? (
             <Card padding={3} radius={2} tone="critical">
-              <Text size={1}>{state.error}</Text>
+              <Stack space={3}>
+                <Text size={1}>{state.error}</Text>
+                <Inline space={2}>
+                  <Button
+                    text="Try again"
+                    icon={ResetIcon}
+                    tone="default"
+                    mode="ghost"
+                    onClick={handleGenerate}
+                    disabled={!brief.trim()}
+                    fontSize={1}
+                    padding={2}
+                  />
+                </Inline>
+              </Stack>
             </Card>
           ) : null}
 
@@ -1816,6 +1825,16 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
                       </Text>
                     ) : null}
                   </Stack>
+                  <Box style={{ marginLeft: 'auto' }}>
+                    <Button
+                      text="Cancel"
+                      mode="ghost"
+                      tone="default"
+                      fontSize={1}
+                      padding={2}
+                      onClick={handleReset}
+                    />
+                  </Box>
                 </Flex>
                 {state.progress !== null ? (
                   <Box


### PR DESCRIPTION
## Summary

Implements all four P1 UX improvements identified in the plugin audit:

- **Cancel button during generation** (#47) — Editors can now abort in-flight generations via a "Cancel" button on the progress card, instead of having to close the entire dialog
- **Retry button on failure** (#48) — Failed generations show a "Try again" button inline with the error, reducing friction to retry
- **Remove feedback auto-dismiss** (#49) — The quality feedback prompt no longer vanishes after 5 seconds; editors must click "Great", "Could be better", or "Skip" to proceed, ensuring feedback isn't silently lost
- **Multi-asset picker in document action** (#50) — "Edit in Lamina" now shows a picker dialog when a document has multiple Lamina-generated assets, listing each by field path, instead of silently opening only the first one

## Test plan

- [ ] Open GenerateDialog, start a generation, verify "Cancel" button appears in the progress card and aborts the generation when clicked
- [ ] Trigger a generation failure (e.g., invalid API key), verify "Try again" button appears in the error card and re-triggers generation
- [ ] Complete a generation and click "Use this", verify the feedback prompt stays visible until a button is clicked (no auto-dismiss)
- [ ] On a document with a single Lamina asset, verify "Edit in Lamina" opens the run URL directly (unchanged behavior)
- [ ] On a document with multiple Lamina assets, verify "Edit in Lamina" shows a picker dialog listing all assets by field path
- [ ] Verify `npm run build` passes cleanly with no type errors

Closes #47, closes #48, closes #49, closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)