### PR TITLE
P2/P3 UX improvements: brief enrichment, history, keyboard shortcuts, and more

### DIFF
--- a/src/actions/generateAllAction.tsx
+++ b/src/actions/generateAllAction.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useState } from 'react';
+import { RocketIcon, CheckmarkCircleIcon } from '@sanity/icons';
+import { Box, Button, Card, Flex, Spinner, Stack, Text } from '@sanity/ui';
+import type {
+  DocumentActionComponent,
+  DocumentActionProps,
+  ObjectSchemaType,
+  SchemaType,
+} from 'sanity';
+import { useSchema } from 'sanity';
+
+/** An image/file field discovered in the document schema. */
+interface AssetField {
+  name: string;
+  /** Human-readable label. */
+  label: string;
+  /** 'image' or 'file'. */
+  type: 'image' | 'file';
+}
+
+/**
+ * Recursively collects all top-level image/file fields from a schema type.
+ */
+function collectAssetFields(schemaType: SchemaType | undefined): AssetField[] {
+  if (!schemaType) return [];
+  const fields: AssetField[] = [];
+
+  if ('fields' in schemaType && Array.isArray((schemaType as ObjectSchemaType).fields)) {
+    for (const field of (schemaType as ObjectSchemaType).fields) {
+      let current: SchemaType | undefined = field.type;
+      while (current) {
+        if (current.name === 'image' || current.name === 'file') {
+          const label = field.type.title
+            || field.name.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()).trim();
+          fields.push({
+            name: field.name,
+            label,
+            type: current.name as 'image' | 'file',
+          });
+          break;
+        }
+        current = current.type;
+      }
+    }
+  }
+
+  return fields;
+}
+
+export function createGenerateAllAction(): DocumentActionComponent {
+  const GenerateAllAction: DocumentActionComponent = (
+    props: DocumentActionProps,
+  ) => {
+    const { type: documentType, published, draft } = props;
+    const schema = useSchema();
+    const [showDialog, setShowDialog] = useState(false);
+
+    const schemaType = schema.get(documentType);
+    const assetFields = collectAssetFields(schemaType);
+    const hasDocument = Boolean(published || draft);
+
+    const handleClick = useCallback(() => {
+      setShowDialog(true);
+    }, []);
+
+    const handleClose = useCallback(() => {
+      setShowDialog(false);
+    }, []);
+
+    // Only show if the document type has 2+ image/file fields
+    if (assetFields.length < 2 || !hasDocument) return null;
+
+    return {
+      label: 'Generate all media',
+      icon: RocketIcon,
+      onHandle: handleClick,
+      dialog: showDialog
+        ? {
+            type: 'dialog' as const,
+            header: 'Generate all Lamina assets',
+            onClose: handleClose,
+            content: (
+              <Box padding={4}>
+                <Stack space={4}>
+                  <Text size={1} muted>
+                    This document has {assetFields.length} image/file fields.
+                    Open each field's asset picker to generate media with Lamina:
+                  </Text>
+                  {assetFields.map((field) => (
+                    <Card key={field.name} padding={3} radius={2} border>
+                      <Flex align="center" justify="space-between">
+                        <Stack space={1}>
+                          <Text size={1} weight="medium">
+                            {field.label}
+                          </Text>
+                          <Text size={0} muted>
+                            {field.type === 'file' ? 'Video/file field' : 'Image field'} — {field.name}
+                          </Text>
+                        </Stack>
+                      </Flex>
+                    </Card>
+                  ))}
+                  <Text size={0} muted>
+                    Tip: Use the "Generate with Lamina" option in each field's
+                    asset picker. Presets are applied automatically based on field names.
+                  </Text>
+                </Stack>
+              </Box>
+            ),
+          }
+        : null,
+    };
+  };
+
+  return GenerateAllAction;
+}

--- a/src/components/AssetPickerGrid.tsx
+++ b/src/components/AssetPickerGrid.tsx
@@ -138,6 +138,11 @@ export function AssetPickerGrid(props: AssetPickerGridProps) {
                 <Text size={0} textOverflow="ellipsis">
                   {asset.originalFilename || asset._id}
                 </Text>
+                {asset.description ? (
+                  <Text size={0} muted textOverflow="ellipsis" style={{ maxHeight: 32, overflow: 'hidden' }}>
+                    {asset.description}
+                  </Text>
+                ) : null}
                 <Flex align="center" justify="space-between">
                   <Text size={0} muted>
                     {formatFileSize(asset.size)}

--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -108,6 +108,8 @@ function resolvePreset(
 
 /** 30 minutes in milliseconds. */
 const GENERATION_TIMEOUT_MS = 30 * 60 * 1000;
+/** Show a warning 5 minutes before timeout. */
+const TIMEOUT_WARNING_MS = GENERATION_TIMEOUT_MS - 5 * 60 * 1000;
 
 /** Prompt suggestions by schema type. */
 const SCHEMA_SUGGESTIONS: Record<string, string[]> = {
@@ -449,6 +451,56 @@ function ParameterField({
   }
 }
 
+/**
+ * Extracts a plain-text excerpt (up to 200 chars) from common document body fields.
+ * Handles plain strings and portable text arrays.
+ */
+function extractDocumentExcerpt(
+  body: unknown,
+  content: unknown,
+  description: string | undefined,
+  excerpt: string | undefined,
+): string | null {
+  // Prefer explicit excerpt/description (usually short summaries)
+  if (excerpt && typeof excerpt === 'string' && excerpt.trim()) {
+    return excerpt.trim().substring(0, 200);
+  }
+  if (description && typeof description === 'string' && description.trim()) {
+    return description.trim().substring(0, 200);
+  }
+
+  // Try to extract plain text from portable text blocks
+  const ptSource = body ?? content;
+  if (Array.isArray(ptSource)) {
+    const textParts: string[] = [];
+    for (const block of ptSource) {
+      if (
+        block &&
+        typeof block === 'object' &&
+        '_type' in block &&
+        (block as Record<string, unknown>)._type === 'block' &&
+        Array.isArray((block as Record<string, unknown>).children)
+      ) {
+        for (const child of (block as Record<string, unknown>).children as Array<Record<string, unknown>>) {
+          if (typeof child.text === 'string') {
+            textParts.push(child.text);
+          }
+        }
+      }
+      if (textParts.join(' ').length >= 200) break;
+    }
+    const joined = textParts.join(' ').trim();
+    if (joined) return joined.substring(0, 200);
+  }
+
+  // Plain string body
+  if (typeof ptSource === 'string' && ptSource.trim()) {
+    return ptSource.trim().substring(0, 200);
+  }
+
+  return null;
+}
+
 // -- Document context for brief pre-filling --
 
 interface DocumentContext {
@@ -527,6 +579,13 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
     || useFormValue(['name']) as string | undefined;
   const documentType = useFormValue(['_type']) as string | undefined;
 
+  // Read common body fields to enrich AI brief suggestions (#51)
+  const rawBody = useFormValue(['body']) as unknown;
+  const rawContent = useFormValue(['content']) as unknown;
+  const rawDescription = useFormValue(['description']) as string | undefined;
+  const rawExcerpt = useFormValue(['excerpt']) as string | undefined;
+  const documentExcerpt = extractDocumentExcerpt(rawBody, rawContent, rawDescription, rawExcerpt);
+
   // Derive field name from the parent path if available
   const parentSchemaType = (props as unknown as Record<string, unknown>).schemaType as
     | { name?: string; description?: string; parent?: { name?: string } }
@@ -560,6 +619,19 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   const effectiveAspectRatio: LaminaAspectRatio | null =
     aspectRatioOverride || detectedRatio?.ratio || null;
 
+  // Listen for regenerate events from field-level "Regenerate" button (#59)
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.brief && typeof detail.brief === 'string') {
+        setBrief(detail.brief);
+        setBriefPreFilled(true);
+      }
+    };
+    window.addEventListener('lamina:regenerate', handler);
+    return () => window.removeEventListener('lamina:regenerate', handler);
+  }, []);
+
   // Pre-fill brief on first render if we have context
   useEffect(() => {
     if (!briefPreFilled && suggestedBrief && !brief) {
@@ -578,6 +650,10 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   // needsInput state
   const [needsInputCtx, setNeedsInputCtx] = useState<NeedsInputContext | null>(null);
   const [collectedInputs, setCollectedInputs] = useState<Record<string, unknown>>({});
+
+  // Timeout warning (#56)
+  const [timeoutWarning, setTimeoutWarning] = useState(false);
+  const timeoutWarningRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Multi-select state (#10)
   const [selectedOutputIds, setSelectedOutputIds] = useState<Set<string>>(new Set());
@@ -633,10 +709,13 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
       setAiSuggestionsLoading(true);
       try {
         const resolvedModality = modality || (assetType === 'file' ? 'video' : 'image');
+        const goalParts = [
+          `${fieldName ? FIELD_LABELS[fieldName] || fieldName : 'media'} for ${documentType || 'content'}`,
+          ...(documentTitle ? [`: ${documentTitle}`] : []),
+          ...(documentExcerpt ? [` — ${documentExcerpt}`] : []),
+        ];
         const briefParams: ContentBriefParams = {
-          goal: documentTitle
-            ? `${fieldName ? FIELD_LABELS[fieldName] || fieldName : 'media'} for ${documentType || 'document'}: ${documentTitle}`
-            : `${fieldName ? FIELD_LABELS[fieldName] || fieldName : 'media'} for ${documentType || 'content'}`,
+          goal: goalParts.join(''),
           modality: resolvedModality,
           count: 3,
           ...(selectedBrandId ? { brandProfileId: selectedBrandId } : {}),
@@ -925,6 +1004,9 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
     });
     setNeedsInputCtx(null);
     setCollectedInputs({});
+    setTimeoutWarning(false);
+    if (timeoutWarningRef.current) clearTimeout(timeoutWarningRef.current);
+    timeoutWarningRef.current = setTimeout(() => setTimeoutWarning(true), TIMEOUT_WARNING_MS);
 
     try {
       const resolvedModality =
@@ -936,6 +1018,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         ...(documentTitle ? { documentTitle } : {}),
         ...(fieldName ? { fieldName } : {}),
         ...(fieldDescription ? { fieldPurpose: fieldDescription } : {}),
+        ...(documentExcerpt ? { documentExcerpt } : {}),
       };
 
       const createParams: LaminaCreateParams & { aspectRatio?: string; metadata?: Record<string, string> } = {
@@ -1141,6 +1224,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   );
 
   const [selecting, setSelecting] = useState(false);
+  const [selectingPhase, setSelectingPhase] = useState<'downloading' | 'uploading' | null>(null);
 
   // -- Quality feedback state (#33) --
   const [feedbackState, setFeedbackState] = useState<{
@@ -1199,8 +1283,10 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   const handleSelectOutput = useCallback(
     async (output: GeneratedOutput) => {
       setSelecting(true);
+      setSelectingPhase('downloading');
       try {
         const url = await resolveAssetUrl(output);
+        setSelectingPhase('uploading');
         const assets = [buildAsset(output, url)];
         setPendingAssets(assets);
         setFeedbackState({
@@ -1210,6 +1296,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         });
       } finally {
         setSelecting(false);
+        setSelectingPhase(null);
       }
     },
     [resolveAssetUrl, buildAsset, state.runId],
@@ -1231,6 +1318,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
     const selected = state.outputs.filter((o) => selectedOutputIds.has(o.id));
     if (selected.length === 0) return;
     setSelecting(true);
+    setSelectingPhase('downloading');
     try {
       const resolved = await Promise.all(
         selected.map(async (o) => {
@@ -1238,6 +1326,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
           return buildAsset(o, url);
         }),
       );
+      setSelectingPhase('uploading');
       setPendingAssets(resolved);
       setFeedbackState({
         runId: state.runId ?? selected[0].id,
@@ -1246,6 +1335,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
       });
     } finally {
       setSelecting(false);
+      setSelectingPhase(null);
     }
   }, [state.outputs, state.runId, selectedOutputIds, resolveAssetUrl, buildAsset]);
 
@@ -1261,11 +1351,35 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
     setNeedsInputCtx(null);
     setCollectedInputs({});
     setSelectedOutputIds(new Set());
+    setTimeoutWarning(false);
+    if (timeoutWarningRef.current) {
+      clearTimeout(timeoutWarningRef.current);
+      timeoutWarningRef.current = null;
+    }
   }, []);
 
   // Sanity types selectionType as 'single' but future versions may support 'multiple'
   const isMultiple = (selectionType as string) === 'multiple';
   const isIdle = state.status === 'idle' || state.status === 'failed';
+
+  // Keyboard shortcuts (#60): Cmd/Ctrl+Enter to generate, Escape to cancel
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        if (isIdle && brief.trim()) {
+          handleGenerate();
+        }
+      }
+      if (e.key === 'Escape' && state.status === 'generating') {
+        e.preventDefault();
+        e.stopPropagation();
+        handleReset();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isIdle, brief, state.status, handleGenerate, handleReset]);
 
   return (
     <Dialog
@@ -1719,13 +1833,15 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
                 <Stack space={2}>
                   <Flex align="center" justify="space-between">
                     <Text size={1}>
-                      Est. {costEstimate.estimatedCredits.expected} credits
+                      Est. {batchMode && batchCount > 1
+                        ? `${costEstimate.estimatedCredits.expected * batchCount} credits (${batchCount} x ${costEstimate.estimatedCredits.expected})`
+                        : `${costEstimate.estimatedCredits.expected} credits`}
                     </Text>
                     <Text size={1} muted>
                       Balance: {costEstimate.currentBalance}
                     </Text>
                   </Flex>
-                  {!costEstimate.affordable ? (
+                  {!costEstimate.affordable || (batchMode && batchCount > 1 && costEstimate.estimatedCredits.expected * batchCount > costEstimate.currentBalance) ? (
                     <Flex align="center" justify="space-between">
                       <Text size={1} weight="medium" style={{ color: 'var(--card-badge-caution-fg-color)' }}>
                         Insufficient credits for this generation
@@ -1856,6 +1972,13 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
                     />
                   </Box>
                 ) : null}
+                {timeoutWarning ? (
+                  <Card padding={2} radius={2} tone="caution">
+                    <Text size={1}>
+                      Generation is taking longer than expected. It will time out in about 5 minutes.
+                    </Text>
+                  </Card>
+                ) : null}
               </Stack>
             </Card>
           ) : null}
@@ -1949,7 +2072,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
                       ) : (
                         <Inline space={2}>
                           <Button
-                            text={selecting ? 'Saving...' : 'Use this'}
+                            text={selecting ? (selectingPhase === 'uploading' ? 'Uploading...' : 'Downloading...') : 'Use this'}
                             tone="positive"
                             icon={CheckmarkCircleIcon}
                             onClick={() => handleSelectOutput(output)}
@@ -1967,7 +2090,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
               {/* Multi-select action */}
               {isMultiple && selectedOutputIds.size > 0 ? (
                 <Button
-                  text={selecting ? 'Saving...' : `Use ${selectedOutputIds.size} selected`}
+                  text={selecting ? (selectingPhase === 'uploading' ? 'Uploading...' : 'Downloading...') : `Use ${selectedOutputIds.size} selected`}
                   tone="positive"
                   icon={CheckmarkCircleIcon}
                   onClick={handleUseSelected}

--- a/src/components/LaminaFieldAction.tsx
+++ b/src/components/LaminaFieldAction.tsx
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import { EditIcon } from '@sanity/icons';
+import { EditIcon, LaunchIcon } from '@sanity/icons';
 import { Button, Flex } from '@sanity/ui';
 import { useClient, useFormValue } from 'sanity';
 import { setDocumentContext } from '../lib/documentContext.js';
+
+interface LaminaAssetMeta {
+  source?: { name?: string; url?: string };
+  description?: string;
+}
 
 interface LaminaImageInputProps {
   value?: {
@@ -18,6 +23,7 @@ export function LaminaImageInput(props: LaminaImageInputProps) {
   const { value, renderDefault, ...rest } = props;
   const client = useClient({ apiVersion: '2024-01-01' });
   const [runUrl, setRunUrl] = useState<string | null>(null);
+  const [previousBrief, setPreviousBrief] = useState<string | null>(null);
 
   // Track document context for the embed iframe
   const documentTitle = useFormValue(['title']) as string | undefined;
@@ -41,25 +47,31 @@ export function LaminaImageInput(props: LaminaImageInputProps) {
   useEffect(() => {
     if (!assetRef) {
       setRunUrl(null);
+      setPreviousBrief(null);
       return;
     }
 
     let cancelled = false;
     client
-      .fetch<{ source?: { name?: string; url?: string } } | null>(
-        '*[_id == $id][0]{ source }',
+      .fetch<LaminaAssetMeta | null>(
+        '*[_id == $id][0]{ source, description }',
         { id: assetRef },
       )
       .then((result) => {
         if (cancelled) return;
         if (result?.source?.name === 'lamina' && result.source.url) {
           setRunUrl(result.source.url);
+          setPreviousBrief(result.description ?? null);
         } else {
           setRunUrl(null);
+          setPreviousBrief(null);
         }
       })
       .catch(() => {
-        if (!cancelled) setRunUrl(null);
+        if (!cancelled) {
+          setRunUrl(null);
+          setPreviousBrief(null);
+        }
       });
 
     return () => {
@@ -67,26 +79,63 @@ export function LaminaImageInput(props: LaminaImageInputProps) {
     };
   }, [client, assetRef]);
 
-  const handleEdit = useCallback(() => {
+  const handleOpenInLamina = useCallback(() => {
     if (runUrl) {
       window.open(runUrl, '_blank', 'noopener');
     }
   }, [runUrl]);
 
+  // Trigger the asset source dialog with previous brief pre-filled via
+  // a custom event that GenerateDialog listens for.
+  const handleRegenerate = useCallback(() => {
+    // Dispatch a custom event that the asset source dialog can pick up
+    // to pre-fill the brief from the previous generation.
+    window.dispatchEvent(
+      new CustomEvent('lamina:regenerate', {
+        detail: { brief: previousBrief },
+      }),
+    );
+    // Find and click the native "Generate with Lamina" asset source button
+    // to open the dialog. This traverses Sanity's DOM to trigger the picker.
+    const el = (rest as Record<string, unknown>).elementProps as
+      | { id?: string }
+      | undefined;
+    if (el?.id) {
+      const wrapper = document.getElementById(el.id);
+      const changeBtn = wrapper?.closest('[data-testid="file-input"]')
+        ?.querySelector('button[data-testid="file-input-upload-button"]')
+        ?? wrapper?.closest('[data-testid="image-input"]')
+          ?.querySelector('button[data-testid="file-input-upload-button"]');
+      if (changeBtn instanceof HTMLElement) {
+        changeBtn.click();
+      }
+    }
+  }, [previousBrief, rest]);
+
   return (
     <>
       {renderDefault({ ...rest, value, renderDefault })}
       {runUrl ? (
-        <Flex paddingTop={2}>
+        <Flex paddingTop={2} gap={2}>
           <Button
-            text="Edit in Lamina"
+            text={previousBrief ? 'Regenerate' : 'Edit in Lamina'}
             icon={EditIcon}
             mode="ghost"
             tone="primary"
             fontSize={1}
             padding={2}
-            onClick={handleEdit}
+            onClick={previousBrief ? handleRegenerate : handleOpenInLamina}
           />
+          {previousBrief ? (
+            <Button
+              icon={LaunchIcon}
+              mode="ghost"
+              fontSize={1}
+              padding={2}
+              title="Open original run in Lamina"
+              onClick={handleOpenInLamina}
+            />
+          ) : null}
         </Flex>
       ) : null}
     </>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { GenerateDialog } from './components/GenerateDialog.js';
 export { LaminaImageInput } from './components/LaminaFieldAction.js';
 export { LaminaTool } from './tool/LaminaTool.js';
 export { createRegenerateAction } from './actions/regenerateAction.js';
+export { createGenerateAllAction } from './actions/generateAllAction.js';
 export { useLamina, LaminaProvider } from './lib/LaminaContext.js';
 export { useLaminaAssets } from './lib/useLaminaAssets.js';
 export { detectAspectRatio, ASPECT_RATIO_OPTIONS } from './lib/aspectRatio.js';

--- a/src/lib/LaminaContext.tsx
+++ b/src/lib/LaminaContext.tsx
@@ -109,8 +109,18 @@ function OAuthLogin({
           Sign in with your Lamina account to generate and manage media assets.
         </Text>
         {error ? (
-          <Card padding={2} radius={2} tone="critical">
-            <Text size={1}>{error}</Text>
+          <Card padding={3} radius={2} tone="critical">
+            <Stack space={2}>
+              <Text size={1}>{error}</Text>
+              <Text size={0} muted>
+                Look for a popup blocked icon in your browser's address bar and allow popups for this site.
+              </Text>
+              <Button
+                text="Try again"
+                mode="ghost"
+                onClick={handleLogin}
+              />
+            </Stack>
           </Card>
         ) : null}
         {loading ? (

--- a/src/lib/recentBriefs.ts
+++ b/src/lib/recentBriefs.ts
@@ -1,15 +1,18 @@
 /**
  * Stores the last few successful briefs per document-type + field-name.
  * Used to show "Recently used" suggestion chips in the GenerateDialog.
+ * Tracks usage count so frequently-used briefs sort higher (#61).
  */
 
 const PREFIX = 'lamina_recent_';
-const MAX_RECENT = 5;
+const MAX_RECENT = 10;
 
-interface RecentBrief {
+export interface RecentBrief {
   brief: string;
   timestamp: number;
   appId?: string;
+  /** Number of times this brief has been used successfully. */
+  useCount: number;
 }
 
 export function getRecentBriefs(documentType?: string, fieldName?: string): RecentBrief[] {
@@ -17,7 +20,9 @@ export function getRecentBriefs(documentType?: string, fieldName?: string): Rece
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return [];
-    return JSON.parse(raw) as RecentBrief[];
+    const parsed = JSON.parse(raw) as RecentBrief[];
+    // Sort by useCount descending, then by timestamp descending
+    return parsed.sort((a, b) => (b.useCount || 1) - (a.useCount || 1) || b.timestamp - a.timestamp);
   } catch {
     return [];
   }
@@ -33,8 +38,15 @@ export function saveRecentBrief(
   const key = `${PREFIX}${documentType ?? '_any'}_${fieldName ?? '_default'}`;
   try {
     const existing = getRecentBriefs(documentType, fieldName);
+    const match = existing.find((r) => r.brief === brief.trim());
+    const entry: RecentBrief = {
+      brief: brief.trim(),
+      timestamp: Date.now(),
+      appId,
+      useCount: (match?.useCount || 0) + 1,
+    };
     const updated = [
-      { brief: brief.trim(), timestamp: Date.now(), appId },
+      entry,
       ...existing.filter((r) => r.brief !== brief.trim()),
     ].slice(0, MAX_RECENT);
     localStorage.setItem(key, JSON.stringify(updated));

--- a/src/lib/useLaminaAssets.ts
+++ b/src/lib/useLaminaAssets.ts
@@ -71,6 +71,7 @@ export function useLaminaAssets(options: UseLaminaAssetsOptions): UseLaminaAsset
           mimeType,
           size,
           _createdAt,
+          description,
           source
         }`,
       );

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -5,6 +5,7 @@ import { LaminaImageInput } from './components/LaminaFieldAction.js';
 import { LaminaProvider } from './lib/LaminaContext.js';
 import { LaminaTool } from './tool/LaminaTool.js';
 import { createRegenerateAction } from './actions/regenerateAction.js';
+import { createGenerateAllAction } from './actions/generateAllAction.js';
 import type { LaminaPluginOptions } from './types.js';
 
 /**
@@ -95,7 +96,7 @@ export const laminaPlugin = definePlugin<LaminaPluginOptions>((options) => {
 
     document: enableDocumentAction
       ? {
-          actions: (prev) => [...prev, createRegenerateAction()],
+          actions: (prev) => [...prev, createRegenerateAction(), createGenerateAllAction()],
         }
       : undefined,
   };

--- a/src/tool/LaminaTool.tsx
+++ b/src/tool/LaminaTool.tsx
@@ -41,6 +41,166 @@ function isLaminaMessage(data: unknown): data is LaminaMessage {
   );
 }
 
+interface HistoryEntry {
+  _id: string;
+  _type: string;
+  _createdAt: string;
+  url: string;
+  originalFilename: string | null;
+  mimeType: string | null;
+  description: string | null;
+  source: { name: string; id: string; url?: string } | null;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return d.toLocaleDateString();
+}
+
+function GenerationHistory() {
+  const sanityClient = useClient({ apiVersion: '2024-01-01' });
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await sanityClient.fetch<HistoryEntry[]>(
+          `*[_type in ["sanity.imageAsset", "sanity.fileAsset"] && source.name == "lamina"] | order(_createdAt desc) [0...50] {
+            _id, _type, _createdAt, url, originalFilename, mimeType, description, source
+          }`,
+        );
+        if (!cancelled) setEntries(result ?? []);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load history');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [sanityClient]);
+
+  if (loading) {
+    return (
+      <Flex align="center" justify="center" padding={5}>
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box padding={4}>
+        <Card padding={3} radius={2} tone="critical">
+          <Text size={1}>{error}</Text>
+        </Card>
+      </Box>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <Flex align="center" justify="center" padding={5}>
+        <Text size={1} muted>No generation history yet</Text>
+      </Flex>
+    );
+  }
+
+  // Group by date
+  const groups: Array<{ label: string; items: HistoryEntry[] }> = [];
+  let currentLabel = '';
+  for (const entry of entries) {
+    const label = formatDate(entry._createdAt);
+    if (label !== currentLabel) {
+      groups.push({ label, items: [entry] });
+      currentLabel = label;
+    } else {
+      groups[groups.length - 1].items.push(entry);
+    }
+  }
+
+  return (
+    <Box padding={3}>
+      <Stack space={4}>
+        <Text size={1} weight="medium">Recent generations</Text>
+        {groups.map((group) => (
+          <Stack key={group.label} space={2}>
+            <Text size={0} muted weight="medium">{group.label}</Text>
+            {group.items.map((entry) => {
+              const isImage = entry._type === 'sanity.imageAsset';
+              return (
+                <Card key={entry._id} padding={2} radius={2} border>
+                  <Flex gap={3} align="center">
+                    {isImage ? (
+                      <img
+                        src={`${entry.url}?w=60&h=60&fit=crop`}
+                        alt=""
+                        style={{ width: 48, height: 48, borderRadius: 4, objectFit: 'cover', flexShrink: 0 }}
+                      />
+                    ) : (
+                      <Box
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 4,
+                          backgroundColor: 'var(--card-bg2-color)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <Text size={0} muted>
+                          {entry.mimeType?.split('/')[1]?.toUpperCase() || 'FILE'}
+                        </Text>
+                      </Box>
+                    )}
+                    <Stack space={1} style={{ flex: 1, minWidth: 0 }}>
+                      {entry.description ? (
+                        <Text size={1} textOverflow="ellipsis">
+                          {entry.description}
+                        </Text>
+                      ) : (
+                        <Text size={1} muted textOverflow="ellipsis">
+                          {entry.originalFilename || entry._id}
+                        </Text>
+                      )}
+                      <Text size={0} muted>
+                        {new Date(entry._createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                        {entry.mimeType ? ` · ${entry.mimeType}` : ''}
+                      </Text>
+                    </Stack>
+                    {entry.source?.url ? (
+                      <Button
+                        icon={LaunchIcon}
+                        mode="ghost"
+                        fontSize={0}
+                        padding={1}
+                        title="Open in Lamina"
+                        onClick={() => window.open(entry.source!.url, '_blank', 'noopener')}
+                      />
+                    ) : null}
+                  </Flex>
+                </Card>
+              );
+            })}
+          </Stack>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
 function AssetBrowser() {
   const [typeFilter, setTypeFilter] = useState<AssetTypeFilter>('all');
   const [search, setSearch] = useState('');
@@ -126,9 +286,10 @@ export function LaminaTool() {
   const sanityClient = useClient({ apiVersion: '2024-01-01' });
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [saving, setSaving] = useState(false);
+  const [savingPhase, setSavingPhase] = useState<'downloading' | 'uploading' | null>(null);
   const [lastSaved, setLastSaved] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'editor' | 'assets'>('editor');
+  const [activeTab, setActiveTab] = useState<'editor' | 'assets' | 'history'>('editor');
 
   const baseUrl = options.baseUrl || LAMINA_ORIGIN;
   // Load iframe without credentials — auth is handled via postMessage handshake
@@ -172,6 +333,7 @@ export function LaminaTool() {
 
       if (msg.type === 'lamina:asset-ready' && msg.url) {
         setSaving(true);
+        setSavingPhase('downloading');
         setErrorMessage(null);
         try {
           const assetType = msg.mediaType === 'video' ? 'file' : 'image';
@@ -210,6 +372,7 @@ export function LaminaTool() {
 
           const blob = await response.blob();
 
+          setSavingPhase('uploading');
           try {
             await sanityClient.assets.upload(assetType, blob, {
               filename,
@@ -232,6 +395,7 @@ export function LaminaTool() {
           console.error('[sanity-plugin-lamina] Failed to save asset:', err);
         } finally {
           setSaving(false);
+          setSavingPhase(null);
         }
       }
     },
@@ -272,12 +436,21 @@ export function LaminaTool() {
                 fontSize={1}
                 padding={2}
               />
+              <Tab
+                id="lamina-tab-history"
+                label="History"
+                aria-controls="lamina-panel-history"
+                selected={activeTab === 'history'}
+                onClick={() => setActiveTab('history')}
+                fontSize={1}
+                padding={2}
+              />
             </TabList>
             {saving ? (
               <Flex align="center" gap={2}>
                 <Spinner />
                 <Text size={1} muted>
-                  Saving to Sanity...
+                  {savingPhase === 'uploading' ? 'Uploading to Sanity...' : 'Downloading asset...'}
                 </Text>
               </Flex>
             ) : null}
@@ -330,6 +503,14 @@ export function LaminaTool() {
           style={{ position: 'absolute', inset: 0, overflowY: 'auto' }}
         >
           <AssetBrowser />
+        </TabPanel>
+        <TabPanel
+          id="lamina-panel-history"
+          aria-labelledby="lamina-tab-history"
+          hidden={activeTab !== 'history'}
+          style={{ position: 'absolute', inset: 0, overflowY: 'auto' }}
+        >
+          <GenerationHistory />
         </TabPanel>
       </Box>
     </Flex>

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export interface LaminaAsset {
   mimeType: string | null;
   size: number | null;
   _createdAt: string;
+  /** The original brief used to generate this asset. */
+  description: string | null;
   source: {
     name: string;
     id: string;


### PR DESCRIPTION
## Summary

Implements 11 of the 12 remaining P2/P3 UX issues from the plugin audit (#62 drag-and-drop deferred — requires cross-component coordination beyond this batch).

### Generation workflow
- **Aggregate batch cost** (#54) — Cost estimate now shows total credits when batch mode is on (e.g. "25 credits (5 x 5)")
- **Timeout warning** (#56) — Caution card appears 5 minutes before the 30-minute generation timeout
- **Document body enrichment** (#51) — AI brief suggestions now include content from body/content/excerpt/description fields via portable text extraction
- **Keyboard shortcuts** (#60) — `Cmd/Ctrl+Enter` to generate, `Escape` to cancel in-flight generation
- **Upload progress phases** (#55) — "Downloading..." → "Uploading..." replaces generic "Saving..." in both GenerateDialog and Studio Tool

### Asset browser & history
- **Brief metadata on assets** (#52) — Asset cards now show the original brief text (stored in `description`) 
- **Generation history tab** (#58) — New "History" tab in Studio Tool showing the 50 most recent Lamina generations grouped by date, with brief text, timestamps, and links to runs

### Authentication
- **OAuth popup guidance** (#57) — Error card now includes helpful text about finding the popup blocked icon, plus a "Try again" button

### Document actions
- **Generate all media** (#53) — New "Generate all media" document action for document types with 2+ image/file fields, listing each field with its type

### Field-level editing
- **In-place regeneration** (#59) — "Edit in Lamina" becomes "Regenerate" when the asset has a stored brief; dispatches `lamina:regenerate` event to pre-fill the GenerateDialog. Original run still accessible via launch icon

### Prompt intelligence
- **Learned suggestions** (#61) — Recent briefs limit increased from 5 to 10, now sorted by frequency (most-used first) instead of most-recent

## Test plan

- [ ] Enable batch mode with 3 variants, select an app — verify cost shows "Est. N credits (3 x M)"
- [ ] Start a generation — verify `Cmd/Ctrl+Enter` triggers generation from brief textarea
- [ ] During generation, press `Escape` — verify generation is cancelled
- [ ] On a document with body content, open asset source — verify AI suggestions reference the document content
- [ ] Click "Use this" on a generated output — verify button shows "Downloading..." then "Uploading..."
- [ ] Browse Assets tab in Studio Tool — verify brief text appears under asset filenames
- [ ] Click "History" tab in Studio Tool — verify recent generations appear grouped by date
- [ ] Trigger OAuth with popup blocked — verify error includes guidance text and "Try again" button
- [ ] On a document with 3+ image fields, verify "Generate all media" appears in document actions
- [ ] On an image field with a Lamina-sourced asset, verify "Regenerate" button appears with launch icon
- [ ] Generate successfully with the same brief 3 times — verify it ranks higher in "Recently used"
- [ ] Run `npm run build` — verify clean compilation

Closes #51, closes #52, closes #53, closes #54, closes #55, closes #56, closes #57, closes #58, closes #59, closes #60, closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)