### PR TITLE
Prompt intelligence: auto-enhance, typeahead, schema-aware templates, bulk generation

### DIFF
--- a/src/actions/generateAllAction.tsx
+++ b/src/actions/generateAllAction.tsx
@@ -1,13 +1,30 @@
-import { useCallback, useState } from 'react';
-import { RocketIcon, CheckmarkCircleIcon } from '@sanity/icons';
-import { Box, Button, Card, Flex, Spinner, Stack, Text } from '@sanity/ui';
+/**
+ * "Generate all media" document action.
+ *
+ * Scans the document schema for empty image/file fields, builds contextual
+ * briefs for each, runs parallel generations, and lets the editor review
+ * and approve results per-field before patching the document.
+ *
+ * Closes #70.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { RocketIcon, CheckmarkCircleIcon, CloseIcon, EditIcon, ResetIcon } from '@sanity/icons';
+import { Box, Button, Card, Flex, Grid, Inline, Label, Spinner, Stack, Text, TextArea } from '@sanity/ui';
 import type {
   DocumentActionComponent,
   DocumentActionProps,
   ObjectSchemaType,
   SchemaType,
+  SanityDocument,
 } from 'sanity';
-import { useSchema } from 'sanity';
+import { useClient, useSchema } from 'sanity';
+import { useLamina } from '../lib/LaminaContext.js';
+import { buildSchemaAwarePrompt, getFieldMeta, extractSiblingContext } from '../lib/schemaContext.js';
+import { enhanceBrief } from '../lib/briefEnhancer.js';
+import { detectAspectRatio } from '../lib/aspectRatio.js';
+import type { GeneratedOutput } from '../types.js';
+import type { ExecutionOutput, LaminaCreateParams } from '@uselamina/sdk';
 
 /** An image/file field discovered in the document schema. */
 interface AssetField {
@@ -16,6 +33,18 @@ interface AssetField {
   label: string;
   /** 'image' or 'file'. */
   type: 'image' | 'file';
+  /** Schema-level description. */
+  description: string | null;
+}
+
+/** State for a single field's generation. */
+interface FieldGenState {
+  field: AssetField;
+  brief: string;
+  status: 'pending' | 'generating' | 'completed' | 'failed' | 'approved' | 'rejected';
+  outputs: GeneratedOutput[];
+  selectedOutputIndex: number;
+  error: string | null;
 }
 
 /**
@@ -32,10 +61,12 @@ function collectAssetFields(schemaType: SchemaType | undefined): AssetField[] {
         if (current.name === 'image' || current.name === 'file') {
           const label = field.type.title
             || field.name.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()).trim();
+          const description = (field.type as unknown as Record<string, unknown>).description as string | null ?? null;
           fields.push({
             name: field.name,
             label,
             type: current.name as 'image' | 'file',
+            description,
           });
           break;
         }
@@ -47,28 +78,325 @@ function collectAssetFields(schemaType: SchemaType | undefined): AssetField[] {
   return fields;
 }
 
+function toGeneratedOutput(out: ExecutionOutput): GeneratedOutput | null {
+  if (out.status !== 'completed' || !out.value || typeof out.value !== 'string') {
+    return null;
+  }
+  return {
+    id: out.id,
+    type: out.type,
+    url: out.value,
+    mimeType: out.mimeType ?? null,
+    label: out.label,
+    dimensions: out.dimensions ?? null,
+    durationSeconds: out.durationSeconds ?? null,
+  };
+}
+
+/** Maximum concurrent generation requests. */
+const CONCURRENCY = 3;
+
 export function createGenerateAllAction(): DocumentActionComponent {
   const GenerateAllAction: DocumentActionComponent = (
     props: DocumentActionProps,
   ) => {
-    const { type: documentType, published, draft } = props;
+    const { id: documentId, type: documentType, published, draft } = props;
     const schema = useSchema();
+    const sanityClient = useClient({ apiVersion: '2024-01-01' });
     const [showDialog, setShowDialog] = useState(false);
 
+    let laminaCtx: ReturnType<typeof useLamina> | null = null;
+    try {
+      laminaCtx = useLamina();
+    } catch {
+      // useLamina throws if not inside LaminaProvider — this action is
+      // registered globally but may render outside the provider context.
+    }
+
     const schemaType = schema.get(documentType);
-    const assetFields = collectAssetFields(schemaType);
-    const hasDocument = Boolean(published || draft);
+    const allFields = useMemo(() => collectAssetFields(schemaType), [schemaType]);
+    const doc = (draft || published) as SanityDocument | null;
+    const hasDocument = Boolean(doc);
+
+    // Find which fields are empty (no asset reference)
+    const emptyFields = useMemo(() => {
+      if (!doc) return allFields;
+      return allFields.filter((f) => {
+        const value = (doc as Record<string, unknown>)[f.name] as Record<string, unknown> | undefined;
+        if (!value) return true;
+        // An image/file field with no asset reference has no _ref in .asset
+        const asset = value.asset as Record<string, unknown> | undefined;
+        return !asset?._ref;
+      });
+    }, [allFields, doc]);
+
+    // Build initial briefs for each empty field
+    const documentTitle = doc
+      ? ((doc as Record<string, unknown>).title as string) ?? ((doc as Record<string, unknown>).name as string) ?? null
+      : null;
+
+    const [fieldStates, setFieldStates] = useState<FieldGenState[]>([]);
+    const [phase, setPhase] = useState<'review' | 'generating' | 'results'>('review');
+    const abortRef = useRef<AbortController | null>(null);
+
+    // Initialize field states when dialog opens
+    useEffect(() => {
+      if (!showDialog) return;
+      const states = emptyFields.map((field): FieldGenState => {
+        const siblingValues = extractSiblingContext(schemaType, (name) => {
+          if (!doc) return undefined;
+          return (doc as Record<string, unknown>)[name];
+        });
+        const fieldMeta = getFieldMeta(schemaType, field.name);
+        const prompt = buildSchemaAwarePrompt(fieldMeta, siblingValues, documentType, documentTitle ?? undefined);
+        return {
+          field,
+          brief: prompt || `${field.label} for ${documentType}${documentTitle ? `: ${documentTitle}` : ''}`,
+          status: 'pending',
+          outputs: [],
+          selectedOutputIndex: 0,
+          error: null,
+        };
+      });
+      setFieldStates(states);
+      setPhase('review');
+    }, [showDialog, emptyFields, schemaType, documentType, documentTitle, doc]);
+
+    const handleBriefChange = useCallback((fieldName: string, newBrief: string) => {
+      setFieldStates((prev) =>
+        prev.map((s) => (s.field.name === fieldName ? { ...s, brief: newBrief } : s)),
+      );
+    }, []);
+
+    const handleRemoveField = useCallback((fieldName: string) => {
+      setFieldStates((prev) => prev.filter((s) => s.field.name !== fieldName));
+    }, []);
+
+    const handleGenerateAll = useCallback(async () => {
+      if (!laminaCtx) return;
+      const { client, options } = laminaCtx;
+
+      abortRef.current?.abort();
+      const abort = new AbortController();
+      abortRef.current = abort;
+      setPhase('generating');
+
+      const pending = [...fieldStates.filter((s) => s.status === 'pending')];
+      const inFlight = new Set<string>();
+
+      async function processField(fs: FieldGenState) {
+        if (abort.signal.aborted) return;
+        inFlight.add(fs.field.name);
+
+        setFieldStates((prev) =>
+          prev.map((s) => (s.field.name === fs.field.name ? { ...s, status: 'generating' } : s)),
+        );
+
+        try {
+          // Enhance brief
+          const enhanced = await enhanceBrief(client, fs.brief, {
+            modality: fs.field.type === 'file' ? 'video' : 'image',
+            documentType,
+            documentTitle: documentTitle ?? undefined,
+            fieldName: fs.field.name,
+          });
+          if (abort.signal.aborted) return;
+
+          const detectedRatio = detectAspectRatio(fs.field.name);
+
+          const createParams: LaminaCreateParams & { aspectRatio?: string; metadata?: Record<string, string> } = {
+            brief: enhanced?.enhanced ?? fs.brief,
+            modality: fs.field.type === 'file' ? 'video' : 'image',
+            ...(detectedRatio ? { aspectRatio: detectedRatio.ratio } : {}),
+            ...(options.webhookUrl ? { webhookUrl: options.webhookUrl } : {}),
+            metadata: {
+              documentType,
+              ...(documentTitle ? { documentTitle } : {}),
+              fieldName: fs.field.name,
+              bulkGeneration: 'true',
+            },
+          };
+
+          const createResult = await client.content.create(createParams);
+          if (abort.signal.aborted) return;
+
+          const runId = createResult.data.runId;
+          if (!runId) {
+            setFieldStates((prev) =>
+              prev.map((s) =>
+                s.field.name === fs.field.name
+                  ? { ...s, status: 'failed', error: 'No run started. Try a more specific brief.' }
+                  : s,
+              ),
+            );
+            return;
+          }
+
+          const result = await client.runs.wait(runId, {
+            intervalMs: 3000,
+            timeoutMs: 10 * 60 * 1000, // 10 min per field in bulk
+          });
+          if (abort.signal.aborted) return;
+
+          if (result.data.status === 'failed') {
+            setFieldStates((prev) =>
+              prev.map((s) =>
+                s.field.name === fs.field.name
+                  ? { ...s, status: 'failed', error: result.data.errorMessage || 'Generation failed.' }
+                  : s,
+              ),
+            );
+            return;
+          }
+
+          const outputs = result.data.outputs
+            .map(toGeneratedOutput)
+            .filter((o): o is GeneratedOutput => o !== null);
+
+          setFieldStates((prev) =>
+            prev.map((s) =>
+              s.field.name === fs.field.name
+                ? { ...s, status: 'completed', outputs, error: outputs.length === 0 ? 'No outputs' : null }
+                : s,
+            ),
+          );
+        } catch (err) {
+          if (abort.signal.aborted) return;
+          setFieldStates((prev) =>
+            prev.map((s) =>
+              s.field.name === fs.field.name
+                ? { ...s, status: 'failed', error: err instanceof Error ? err.message : 'Unknown error' }
+                : s,
+            ),
+          );
+        } finally {
+          inFlight.delete(fs.field.name);
+        }
+      }
+
+      // Process with concurrency limit
+      let idx = 0;
+      async function runNext(): Promise<void> {
+        while (idx < pending.length && !abort.signal.aborted) {
+          if (inFlight.size >= CONCURRENCY) {
+            await new Promise((r) => setTimeout(r, 500));
+            continue;
+          }
+          const current = pending[idx++];
+          processField(current);
+        }
+      }
+
+      await runNext();
+      // Wait for in-flight to finish
+      while (inFlight.size > 0 && !abort.signal.aborted) {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+
+      if (!abort.signal.aborted) {
+        setPhase('results');
+      }
+    }, [fieldStates, laminaCtx, documentType, documentTitle]);
+
+    const handleApprove = useCallback((fieldName: string) => {
+      setFieldStates((prev) =>
+        prev.map((s) => (s.field.name === fieldName ? { ...s, status: 'approved' } : s)),
+      );
+    }, []);
+
+    const handleReject = useCallback((fieldName: string) => {
+      setFieldStates((prev) =>
+        prev.map((s) => (s.field.name === fieldName ? { ...s, status: 'rejected' } : s)),
+      );
+    }, []);
+
+    const handleSelectOutput = useCallback((fieldName: string, index: number) => {
+      setFieldStates((prev) =>
+        prev.map((s) => (s.field.name === fieldName ? { ...s, selectedOutputIndex: index } : s)),
+      );
+    }, []);
+
+    const handleCommitApproved = useCallback(async () => {
+      if (!laminaCtx) return;
+      const { client } = laminaCtx;
+      const approved = fieldStates.filter((s) => s.status === 'approved' && s.outputs.length > 0);
+      if (approved.length === 0) return;
+
+      for (const fs of approved) {
+        const output = fs.outputs[fs.selectedOutputIndex] ?? fs.outputs[0];
+        if (!output) continue;
+
+        try {
+          // Transfer asset to get a stable CDN URL
+          const mediaType = output.type === 'video' ? 'video' : 'image';
+          let cdnUrl = output.url;
+          try {
+            const transfer = await client.publishing.transferAsset({
+              sourceUrl: output.url,
+              mediaType: mediaType as 'image' | 'video',
+              filename: `lamina-bulk-${fs.field.name}-${output.id}`,
+            });
+            cdnUrl = transfer.data.cdnUrl;
+          } catch {
+            // Fall back to direct URL
+          }
+
+          // Upload to Sanity
+          const assetType = fs.field.type === 'file' ? 'file' : 'image';
+          const response = await fetch(cdnUrl);
+          const blob = await response.blob();
+          const extension = output.mimeType?.split('/')[1] || 'png';
+          const file = new File([blob], `lamina-${fs.field.name}.${extension}`, {
+            type: output.mimeType || 'image/png',
+          });
+
+          const asset = await sanityClient.assets.upload(assetType, file, {
+            filename: `lamina-${fs.field.name}.${extension}`,
+            source: {
+              name: 'lamina',
+              id: output.id,
+              url: output.url,
+            },
+            description: fs.brief,
+            creditLine: 'Generated by Lamina',
+          });
+
+          // Patch the document field
+          await sanityClient
+            .patch(documentId)
+            .set({
+              [fs.field.name]: {
+                _type: fs.field.type,
+                asset: {
+                  _type: 'reference',
+                  _ref: asset._id,
+                },
+              },
+            })
+            .commit();
+        } catch {
+          // Best-effort — individual field failures don't block others
+        }
+      }
+
+      setShowDialog(false);
+    }, [fieldStates, laminaCtx, sanityClient, documentId]);
 
     const handleClick = useCallback(() => {
       setShowDialog(true);
     }, []);
 
     const handleClose = useCallback(() => {
+      abortRef.current?.abort();
       setShowDialog(false);
     }, []);
 
     // Only show if the document type has 2+ image/file fields
-    if (assetFields.length < 2 || !hasDocument) return null;
+    if (allFields.length < 2 || !hasDocument) return null;
+
+    const approvedCount = fieldStates.filter((s) => s.status === 'approved').length;
+    const completedCount = fieldStates.filter((s) => s.status === 'completed' || s.status === 'approved' || s.status === 'rejected').length;
+    const totalCount = fieldStates.length;
 
     return {
       label: 'Generate all media',
@@ -77,33 +405,230 @@ export function createGenerateAllAction(): DocumentActionComponent {
       dialog: showDialog
         ? {
             type: 'dialog' as const,
-            header: 'Generate all Lamina assets',
+            header: `Generate all media (${emptyFields.length} empty fields)`,
             onClose: handleClose,
             content: (
               <Box padding={4}>
                 <Stack space={4}>
-                  <Text size={1} muted>
-                    This document has {assetFields.length} image/file fields.
-                    Open each field's asset picker to generate media with Lamina:
-                  </Text>
-                  {assetFields.map((field) => (
-                    <Card key={field.name} padding={3} radius={2} border>
-                      <Flex align="center" justify="space-between">
-                        <Stack space={1}>
-                          <Text size={1} weight="medium">
-                            {field.label}
-                          </Text>
-                          <Text size={0} muted>
-                            {field.type === 'file' ? 'Video/file field' : 'Image field'} — {field.name}
-                          </Text>
+                  {/* Phase: Review briefs before generating */}
+                  {phase === 'review' ? (
+                    <>
+                      <Text size={1} muted>
+                        Review and edit the briefs for each empty media field, then generate all at once.
+                      </Text>
+                      {fieldStates.length === 0 ? (
+                        <Card padding={3} radius={2} tone="positive">
+                          <Flex align="center" gap={2}>
+                            <CheckmarkCircleIcon />
+                            <Text size={1}>All media fields are already filled.</Text>
+                          </Flex>
+                        </Card>
+                      ) : (
+                        <Stack space={3}>
+                          {fieldStates.map((fs) => (
+                            <Card key={fs.field.name} padding={3} radius={2} border>
+                              <Stack space={2}>
+                                <Flex align="center" justify="space-between">
+                                  <Stack space={1}>
+                                    <Text size={1} weight="medium">{fs.field.label}</Text>
+                                    <Text size={0} muted>
+                                      {fs.field.type === 'file' ? 'Video/file' : 'Image'} — {fs.field.name}
+                                    </Text>
+                                  </Stack>
+                                  <Button
+                                    icon={CloseIcon}
+                                    mode="bleed"
+                                    fontSize={0}
+                                    padding={1}
+                                    title="Remove from batch"
+                                    onClick={() => handleRemoveField(fs.field.name)}
+                                  />
+                                </Flex>
+                                <TextArea
+                                  value={fs.brief}
+                                  onChange={(e) => handleBriefChange(fs.field.name, e.currentTarget.value)}
+                                  rows={2}
+                                  fontSize={1}
+                                />
+                              </Stack>
+                            </Card>
+                          ))}
+                          <Button
+                            text={`Generate ${fieldStates.length} assets`}
+                            icon={RocketIcon}
+                            tone="primary"
+                            onClick={handleGenerateAll}
+                            disabled={fieldStates.length === 0 || !laminaCtx}
+                          />
                         </Stack>
+                      )}
+                    </>
+                  ) : null}
+
+                  {/* Phase: Generating */}
+                  {phase === 'generating' ? (
+                    <>
+                      <Flex align="center" gap={2}>
+                        <Spinner />
+                        <Text size={1}>Generating {totalCount} assets...</Text>
                       </Flex>
-                    </Card>
-                  ))}
-                  <Text size={0} muted>
-                    Tip: Use the "Generate with Lamina" option in each field's
-                    asset picker. Presets are applied automatically based on field names.
-                  </Text>
+                      <Stack space={2}>
+                        {fieldStates.map((fs) => (
+                          <Card
+                            key={fs.field.name}
+                            padding={2}
+                            radius={2}
+                            border
+                            tone={
+                              fs.status === 'completed' ? 'positive'
+                                : fs.status === 'failed' ? 'critical'
+                                  : fs.status === 'generating' ? 'primary'
+                                    : 'default'
+                            }
+                          >
+                            <Flex align="center" gap={2}>
+                              {fs.status === 'generating' ? <Spinner /> : null}
+                              {fs.status === 'completed' ? <CheckmarkCircleIcon /> : null}
+                              <Text size={1}>
+                                {fs.field.label}
+                                {fs.status === 'generating' ? ' — generating...' : ''}
+                                {fs.status === 'completed' ? ` — ${fs.outputs.length} output(s)` : ''}
+                                {fs.status === 'failed' ? ` — ${fs.error}` : ''}
+                                {fs.status === 'pending' ? ' — queued' : ''}
+                              </Text>
+                            </Flex>
+                          </Card>
+                        ))}
+                      </Stack>
+                      <Button
+                        text="Cancel"
+                        mode="ghost"
+                        onClick={() => {
+                          abortRef.current?.abort();
+                          setPhase('results');
+                        }}
+                      />
+                    </>
+                  ) : null}
+
+                  {/* Phase: Results — approve/reject per field */}
+                  {phase === 'results' ? (
+                    <>
+                      <Text size={1} muted>
+                        Review the generated assets. Approve the ones you want to use.
+                      </Text>
+                      <Stack space={3}>
+                        {fieldStates.map((fs) => (
+                          <Card
+                            key={fs.field.name}
+                            padding={3}
+                            radius={2}
+                            border
+                            tone={
+                              fs.status === 'approved' ? 'positive'
+                                : fs.status === 'rejected' ? 'critical'
+                                  : fs.status === 'failed' ? 'critical'
+                                    : 'default'
+                            }
+                          >
+                            <Stack space={2}>
+                              <Text size={1} weight="medium">{fs.field.label}</Text>
+                              <Text size={0} muted>{fs.brief}</Text>
+
+                              {fs.status === 'failed' ? (
+                                <Text size={0} style={{ color: 'var(--card-badge-critical-fg-color)' }}>
+                                  {fs.error}
+                                </Text>
+                              ) : null}
+
+                              {(fs.status === 'completed' || fs.status === 'approved' || fs.status === 'rejected') && fs.outputs.length > 0 ? (
+                                <>
+                                  <Grid columns={Math.min(fs.outputs.length, 3)} gap={2}>
+                                    {fs.outputs.map((output, idx) => (
+                                      <Card
+                                        key={output.id}
+                                        padding={1}
+                                        radius={2}
+                                        border
+                                        tone={fs.selectedOutputIndex === idx ? 'primary' : 'default'}
+                                        style={{ cursor: 'pointer' }}
+                                        onClick={() => handleSelectOutput(fs.field.name, idx)}
+                                      >
+                                        {output.type === 'video' ? (
+                                          <video
+                                            src={output.url}
+                                            style={{ width: '100%', borderRadius: 4, maxHeight: 120, objectFit: 'contain' }}
+                                          />
+                                        ) : (
+                                          <img
+                                            src={output.url}
+                                            alt={output.label}
+                                            style={{ width: '100%', borderRadius: 4, maxHeight: 120, objectFit: 'contain' }}
+                                          />
+                                        )}
+                                      </Card>
+                                    ))}
+                                  </Grid>
+                                  {fs.status === 'completed' ? (
+                                    <Inline space={2}>
+                                      <Button
+                                        text="Approve"
+                                        icon={CheckmarkCircleIcon}
+                                        tone="positive"
+                                        fontSize={0}
+                                        padding={2}
+                                        onClick={() => handleApprove(fs.field.name)}
+                                      />
+                                      <Button
+                                        text="Reject"
+                                        icon={CloseIcon}
+                                        mode="ghost"
+                                        fontSize={0}
+                                        padding={2}
+                                        onClick={() => handleReject(fs.field.name)}
+                                      />
+                                    </Inline>
+                                  ) : null}
+                                  {fs.status === 'approved' ? (
+                                    <Text size={0} style={{ color: 'var(--card-badge-positive-fg-color)' }}>Approved</Text>
+                                  ) : null}
+                                  {fs.status === 'rejected' ? (
+                                    <Text size={0} muted>Rejected</Text>
+                                  ) : null}
+                                </>
+                              ) : null}
+                            </Stack>
+                          </Card>
+                        ))}
+                      </Stack>
+
+                      <Flex align="center" justify="space-between">
+                        <Text size={1} muted>
+                          {approvedCount} of {completedCount} approved
+                        </Text>
+                        <Inline space={2}>
+                          <Button
+                            text="Back to edit"
+                            icon={EditIcon}
+                            mode="ghost"
+                            onClick={() => {
+                              setFieldStates((prev) =>
+                                prev.map((s) => ({ ...s, status: 'pending' as const, outputs: [], error: null })),
+                              );
+                              setPhase('review');
+                            }}
+                          />
+                          <Button
+                            text={`Save ${approvedCount} asset${approvedCount !== 1 ? 's' : ''} to document`}
+                            icon={CheckmarkCircleIcon}
+                            tone="positive"
+                            onClick={handleCommitApproved}
+                            disabled={approvedCount === 0}
+                          />
+                        </Inline>
+                      </Flex>
+                    </>
+                  ) : null}
                 </Stack>
               </Box>
             ),

--- a/src/components/GenerateDialog.tsx
+++ b/src/components/GenerateDialog.tsx
@@ -20,6 +20,7 @@ import {
   TextInput,
 } from '@sanity/ui';
 import {
+  BoltIcon,
   CheckmarkCircleIcon,
   ChevronDownIcon,
   ChevronUpIcon,
@@ -29,7 +30,7 @@ import {
   UploadIcon,
 } from '@sanity/icons';
 import type { AssetFromSource, AssetSourceComponentProps } from 'sanity';
-import { useFormValue } from 'sanity';
+import { useFormValue, useSchema } from 'sanity';
 import { useLaminaAssets } from '../lib/useLaminaAssets.js';
 import { AssetPickerGrid } from './AssetPickerGrid.js';
 import type { AssetTypeFilter, LaminaAsset, LaminaPreset } from '../types.js';
@@ -70,6 +71,11 @@ import { getRecentBriefs, saveRecentBrief } from '../lib/recentBriefs.js';
 import { detectAspectRatio, ASPECT_RATIO_OPTIONS } from '../lib/aspectRatio.js';
 import type { LaminaAspectRatio } from '../lib/aspectRatio.js';
 import type { GeneratedOutput, GenerationState } from '../types.js';
+import { enhanceBrief } from '../lib/briefEnhancer.js';
+import type { EnhanceResult } from '../lib/briefEnhancer.js';
+import { useTypeahead } from '../lib/useTypeahead.js';
+import { getFieldMeta, extractSiblingContext, buildSchemaAwarePrompt } from '../lib/schemaContext.js';
+import type { SiblingValue } from '../lib/schemaContext.js';
 
 const MODALITIES = [
   { value: '', label: 'Auto-detect' },
@@ -687,6 +693,41 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
   const [aiSuggestionsLoading, setAiSuggestionsLoading] = useState(false);
   const aiSuggestionsCacheKey = useRef<string | null>(null);
 
+  // -- Enhance brief state (#66) --
+  const [enhanceEnabled, setEnhanceEnabled] = useState(true);
+  const [enhanceResult, setEnhanceResult] = useState<EnhanceResult | null>(null);
+  const [enhanceLoading, setEnhanceLoading] = useState(false);
+  /** Tracks whether the current brief came from an AI suggestion (already optimized). */
+  const [briefFromAi, setBriefFromAi] = useState(false);
+
+  // -- Schema-aware context (#67) --
+  const sanitySchema = useSchema();
+  const schemaType = documentType ? sanitySchema.get(documentType) : undefined;
+  const fieldMeta = getFieldMeta(schemaType, fieldName ?? '');
+  const siblingValues: SiblingValue[] = extractSiblingContext(schemaType, (name) => {
+    // We read a limited set of known context fields via useFormValue equivalents.
+    // Since hooks can't be called dynamically, we read them via the already-extracted values.
+    if (name === 'title') return documentTitle;
+    if (name === 'description') return rawDescription;
+    return undefined;
+  });
+  const schemaAwarePrompt = buildSchemaAwarePrompt(fieldMeta, siblingValues, documentType, documentTitle ?? undefined);
+
+  // -- Typeahead hook (#65) --
+  const typeahead = useTypeahead(
+    client,
+    brief,
+    {
+      modality: modality || (assetType === 'file' ? 'video' : 'image'),
+      brandProfileId: selectedBrandId || undefined,
+      documentType,
+      documentTitle: documentTitle ?? undefined,
+      fieldName,
+      documentExcerpt: documentExcerpt ?? undefined,
+    },
+    (state.status === 'idle' || state.status === 'failed') && brief.length >= 8,
+  );
+
   // Batch generation state
   const [batchMode, setBatchMode] = useState(false);
   const [batchCount, setBatchCount] = useState(2);
@@ -1012,6 +1053,26 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
       const resolvedModality =
         modality || (assetType === 'file' ? 'video' : 'image');
 
+      // -- Enhance brief before generation (#66) --
+      let finalBrief = brief.trim();
+      if (enhanceEnabled && !briefFromAi) {
+        setEnhanceLoading(true);
+        const result = await enhanceBrief(client, finalBrief, {
+          modality: resolvedModality,
+          brandProfileId: selectedBrandId || undefined,
+          documentType,
+          documentTitle: documentTitle ?? undefined,
+          fieldName,
+          documentExcerpt: documentExcerpt ?? undefined,
+        });
+        setEnhanceLoading(false);
+        if (abort.signal.aborted) return;
+        if (result) {
+          setEnhanceResult(result);
+          finalBrief = result.enhanced;
+        }
+      }
+
       // Silent enrichment — context from the document, not visible in UI
       const metadata: Record<string, string> = {
         ...(documentType ? { documentType } : {}),
@@ -1019,10 +1080,15 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         ...(fieldName ? { fieldName } : {}),
         ...(fieldDescription ? { fieldPurpose: fieldDescription } : {}),
         ...(documentExcerpt ? { documentExcerpt } : {}),
+        // Schema-aware enrichment (#67)
+        ...(fieldMeta?.description ? { fieldSchemaDescription: fieldMeta.description } : {}),
+        ...(siblingValues.length > 0
+          ? { documentContext: siblingValues.map((s) => `${s.fieldName}: ${s.value}`).join('; ') }
+          : {}),
       };
 
       const createParams: LaminaCreateParams & { aspectRatio?: string; metadata?: Record<string, string> } = {
-        brief: brief.trim(),
+        brief: finalBrief,
         modality: resolvedModality,
         ...(activePreset?.aspectRatio ? { aspectRatio: activePreset.aspectRatio } : {}),
         ...(activePreset?.platform ? { platform: activePreset.platform } : {}),
@@ -1180,7 +1246,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
         progress: null,
       }));
     }
-  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, effectiveAspectRatio, activePreset, client, documentType, documentTitle, fieldName, fieldDescription]);
+  }, [brief, modality, assetType, selectedAppId, selectedBrandId, selectedCampaignId, batchMode, batchCount, options.webhookUrl, effectiveAspectRatio, activePreset, client, documentType, documentTitle, fieldName, fieldDescription, documentExcerpt, enhanceEnabled, briefFromAi, fieldMeta, siblingValues]);
 
   // Proxy a CDN URL through transferAsset to avoid CORS issues
   const resolveAssetUrl = useCallback(
@@ -1352,6 +1418,8 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
     setCollectedInputs({});
     setSelectedOutputIds(new Set());
     setTimeoutWarning(false);
+    setEnhanceResult(null);
+    setEnhanceLoading(false);
     if (timeoutWarningRef.current) {
       clearTimeout(timeoutWarningRef.current);
       timeoutWarningRef.current = null;
@@ -1501,6 +1569,21 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
             ) : null}
             {!brief && isIdle ? (
               <Stack space={2}>
+                {/* Schema-aware suggestion (#67) */}
+                {schemaAwarePrompt ? (
+                  <Stack space={1}>
+                    <Text size={0} muted weight="medium">From your schema</Text>
+                    <Button
+                      text={schemaAwarePrompt.length > 60 ? `${schemaAwarePrompt.substring(0, 60)}...` : schemaAwarePrompt}
+                      title={schemaAwarePrompt}
+                      mode="ghost"
+                      fontSize={0}
+                      padding={2}
+                      tone="positive"
+                      onClick={() => setBrief(schemaAwarePrompt)}
+                    />
+                  </Stack>
+                ) : null}
                 {aiSuggestionsLoading ? (
                   <Flex align="center" gap={2}>
                     <Spinner />
@@ -1519,7 +1602,7 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
                           fontSize={0}
                           padding={2}
                           tone="primary"
-                          onClick={() => setBrief(c.prompt)}
+                          onClick={() => { setBrief(c.prompt); setBriefFromAi(true); }}
                         />
                       ))}
                     </Inline>
@@ -1543,16 +1626,75 @@ export function GenerateDialog(props: AssetSourceComponentProps) {
               value={brief}
               onChange={(e) => {
                 setBrief(e.currentTarget.value);
+                setBriefFromAi(false);
                 if (briefPreFilled) setBriefPreFilled(false);
               }}
               placeholder="Product photo of white sneakers on marble surface, lifestyle aesthetic"
               rows={3}
               disabled={state.status === 'generating'}
             />
+            {/* Typeahead suggestions as you type (#65) */}
+            {brief && isIdle && typeahead.suggestions.length > 0 ? (
+              <Stack space={1}>
+                <Flex align="center" gap={2}>
+                  <Text size={0} muted weight="medium">Suggestions</Text>
+                  {typeahead.loading ? <Spinner /> : null}
+                </Flex>
+                <Inline space={1}>
+                  {typeahead.suggestions.map((c) => (
+                    <Button
+                      key={c.title}
+                      text={c.prompt.length > 50 ? `${c.prompt.substring(0, 50)}...` : c.prompt}
+                      title={`${c.title}: ${c.rationale}`}
+                      mode="ghost"
+                      fontSize={0}
+                      padding={2}
+                      tone="primary"
+                      onClick={() => { setBrief(c.prompt); setBriefFromAi(true); typeahead.clear(); }}
+                    />
+                  ))}
+                </Inline>
+              </Stack>
+            ) : brief && isIdle && typeahead.loading ? (
+              <Flex align="center" gap={2}>
+                <Spinner />
+                <Text size={0} muted>Finding suggestions...</Text>
+              </Flex>
+            ) : null}
             {briefPreFilled && suggestedBrief ? (
               <Text size={0} muted>
                 Suggested from document context
               </Text>
+            ) : null}
+            {/* Enhance brief toggle (#66) */}
+            {isIdle ? (
+              <Flex align="center" gap={2}>
+                <Checkbox
+                  id="lamina-enhance-brief"
+                  checked={enhanceEnabled}
+                  onChange={(e) => setEnhanceEnabled(e.currentTarget.checked)}
+                />
+                <Label htmlFor="lamina-enhance-brief" size={0} muted>
+                  Enhance brief before generating
+                </Label>
+                <BoltIcon style={{ opacity: enhanceEnabled ? 1 : 0.3 }} />
+              </Flex>
+            ) : null}
+            {/* Show enhanced brief preview after generation starts */}
+            {enhanceResult && state.status !== 'idle' ? (
+              <Card padding={2} radius={2} tone="positive" border>
+                <Stack space={1}>
+                  <Text size={0} weight="medium">Enhanced: {enhanceResult.title}</Text>
+                  <Text size={0} muted>{enhanceResult.enhanced}</Text>
+                  <Text size={0} muted style={{ fontStyle: 'italic' }}>{enhanceResult.rationale}</Text>
+                </Stack>
+              </Card>
+            ) : null}
+            {enhanceLoading ? (
+              <Flex align="center" gap={2}>
+                <Spinner />
+                <Text size={0} muted>Enhancing your brief...</Text>
+              </Flex>
             ) : null}
           </Stack>
 

--- a/src/lib/briefEnhancer.ts
+++ b/src/lib/briefEnhancer.ts
@@ -1,0 +1,105 @@
+/**
+ * Brief enhancement utilities.
+ *
+ * Calls `client.content.brief()` to refine a rough user-written prompt into
+ * an optimized generation prompt.  Also builds a silent metadata enrichment
+ * object from document context so the Lamina API receives richer signals
+ * without changing what the user sees in the text field.
+ *
+ * Closes #66.
+ */
+
+import type { LaminaClient, ContentBriefParams, ContentConcept } from '@uselamina/sdk';
+
+export interface EnhanceResult {
+  /** The optimized prompt text. */
+  enhanced: string;
+  /** Title of the concept (for display). */
+  title: string;
+  /** Short rationale explaining the enhancement. */
+  rationale: string;
+}
+
+/**
+ * Ask the Lamina API to rewrite `rawBrief` into a higher-quality prompt.
+ * Returns `null` if the API fails (enhancement is best-effort).
+ */
+export async function enhanceBrief(
+  client: LaminaClient,
+  rawBrief: string,
+  context: {
+    modality?: string;
+    brandProfileId?: string;
+    documentType?: string;
+    documentTitle?: string;
+    fieldName?: string;
+    documentExcerpt?: string;
+  },
+): Promise<EnhanceResult | null> {
+  try {
+    const goalParts: string[] = [rawBrief];
+    if (context.documentTitle) {
+      goalParts.push(`Context: ${context.documentType ?? 'content'} titled "${context.documentTitle}"`);
+    }
+    if (context.fieldName) {
+      goalParts.push(`Target field: ${context.fieldName}`);
+    }
+    if (context.documentExcerpt) {
+      goalParts.push(`Content excerpt: ${context.documentExcerpt}`);
+    }
+
+    const params: ContentBriefParams = {
+      goal: goalParts.join('. '),
+      modality: context.modality || 'image',
+      count: 1,
+      ...(context.brandProfileId ? { brandProfileId: context.brandProfileId } : {}),
+    };
+
+    const result = await client.content.brief(params);
+    const concepts: ContentConcept[] = result.data?.concepts ?? [];
+    if (concepts.length === 0) return null;
+
+    const best = concepts[0];
+    return {
+      enhanced: best.prompt,
+      title: best.title,
+      rationale: best.rationale,
+    };
+  } catch {
+    // Enhancement is best-effort; fall back gracefully.
+    return null;
+  }
+}
+
+export interface SilentEnrichment {
+  metadata: Record<string, string>;
+}
+
+/**
+ * Build a metadata bag from document context that is sent alongside the
+ * generation request.  This enriches the API call without being visible
+ * in the brief textarea.
+ */
+export function buildSilentEnrichment(context: {
+  documentType?: string;
+  documentTitle?: string;
+  fieldName?: string;
+  fieldDescription?: string;
+  documentExcerpt?: string;
+  brandProfileName?: string;
+  targetDimensions?: string;
+  platform?: string;
+}): SilentEnrichment {
+  const metadata: Record<string, string> = {};
+
+  if (context.documentType) metadata.documentType = context.documentType;
+  if (context.documentTitle) metadata.documentTitle = context.documentTitle;
+  if (context.fieldName) metadata.fieldName = context.fieldName;
+  if (context.fieldDescription) metadata.fieldPurpose = context.fieldDescription;
+  if (context.documentExcerpt) metadata.documentExcerpt = context.documentExcerpt;
+  if (context.brandProfileName) metadata.brandTone = context.brandProfileName;
+  if (context.targetDimensions) metadata.targetDimensions = context.targetDimensions;
+  if (context.platform) metadata.platform = context.platform;
+
+  return { metadata };
+}

--- a/src/lib/schemaContext.ts
+++ b/src/lib/schemaContext.ts
@@ -1,0 +1,191 @@
+/**
+ * Schema-aware context extraction for intelligent prompt generation.
+ *
+ * Uses Sanity's schema introspection to read field validation rules,
+ * descriptions, and sibling field values to generate richer, more
+ * context-aware prompts.
+ *
+ * Closes #67.
+ */
+
+import type { ObjectSchemaType, SchemaType } from 'sanity';
+
+export interface SchemaFieldMeta {
+  /** The field name. */
+  name: string;
+  /** The field title (human-readable). */
+  title: string;
+  /** The schema-level description, if defined. */
+  description: string | null;
+  /** The base type ('image' or 'file'). */
+  baseType: 'image' | 'file';
+  /** Whether hotspot/crop is enabled for the field. */
+  hasHotspot: boolean;
+  /** Accept filter if defined on a file field (e.g. 'image/*', 'video/*'). */
+  acceptFilter: string | null;
+}
+
+/**
+ * Extract metadata about a specific image/file field from the schema.
+ */
+export function getFieldMeta(
+  schemaType: SchemaType | undefined,
+  fieldName: string,
+): SchemaFieldMeta | null {
+  if (!schemaType || !('fields' in schemaType)) return null;
+
+  const objectType = schemaType as ObjectSchemaType;
+  const field = objectType.fields.find((f) => f.name === fieldName);
+  if (!field) return null;
+
+  let baseType: 'image' | 'file' | null = null;
+  let current: SchemaType | undefined = field.type;
+  while (current) {
+    if (current.name === 'image') { baseType = 'image'; break; }
+    if (current.name === 'file') { baseType = 'file'; break; }
+    current = current.type;
+  }
+  if (!baseType) return null;
+
+  const options = (field.type as unknown as Record<string, unknown>).options as Record<string, unknown> | undefined;
+  const hasHotspot = Boolean(options?.hotspot);
+  const acceptFilter = (options?.accept as string) ?? null;
+
+  return {
+    name: field.name,
+    title: field.type.title ?? field.name.replace(/([A-Z])/g, ' $1').trim(),
+    description: (field.type as unknown as Record<string, unknown>).description as string | null ?? null,
+    baseType,
+    hasHotspot,
+    acceptFilter,
+  };
+}
+
+/** A key-value pair extracted from sibling fields. */
+export interface SiblingValue {
+  fieldName: string;
+  title: string;
+  value: string;
+}
+
+/**
+ * Field names commonly useful as context when generating media.
+ * These are read from the document to enrich prompts.
+ */
+const CONTEXT_FIELDS = [
+  'title', 'name', 'headline', 'subtitle',
+  'category', 'tags', 'color', 'colours', 'colors',
+  'brand', 'style', 'theme', 'mood',
+  'slug',
+] as const;
+
+/**
+ * Extract useful sibling field values from the document that could
+ * enrich a media generation prompt.
+ *
+ * @param schemaType The document schema type.
+ * @param getFieldValue A callback that reads a field value (typically from useFormValue).
+ */
+export function extractSiblingContext(
+  schemaType: SchemaType | undefined,
+  getFieldValue: (fieldName: string) => unknown,
+): SiblingValue[] {
+  if (!schemaType || !('fields' in schemaType)) return [];
+
+  const objectType = schemaType as ObjectSchemaType;
+  const results: SiblingValue[] = [];
+
+  for (const contextField of CONTEXT_FIELDS) {
+    const field = objectType.fields.find((f) => f.name === contextField);
+    if (!field) continue;
+
+    const value = getFieldValue(contextField);
+    if (!value) continue;
+
+    let stringValue: string | null = null;
+
+    if (typeof value === 'string' && value.trim()) {
+      stringValue = value.trim();
+    } else if (Array.isArray(value)) {
+      // Handle arrays like tags: ['tag1', 'tag2']
+      const strings = value
+        .filter((v): v is string => typeof v === 'string')
+        .slice(0, 5);
+      if (strings.length > 0) {
+        stringValue = strings.join(', ');
+      }
+      // Handle reference arrays with name/title
+      const named = value
+        .filter((v): v is Record<string, unknown> => typeof v === 'object' && v !== null)
+        .map((v) => (v.title || v.name || v.label) as string | undefined)
+        .filter((v): v is string => Boolean(v))
+        .slice(0, 5);
+      if (!stringValue && named.length > 0) {
+        stringValue = named.join(', ');
+      }
+    } else if (typeof value === 'object' && value !== null) {
+      // Handle slug objects
+      const slug = (value as Record<string, unknown>).current as string | undefined;
+      if (slug) stringValue = slug;
+    }
+
+    if (stringValue) {
+      results.push({
+        fieldName: contextField,
+        title: field.type.title ?? contextField,
+        value: stringValue.substring(0, 100),
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Build a context-rich prompt suggestion from schema metadata and
+ * sibling field values.
+ */
+export function buildSchemaAwarePrompt(
+  fieldMeta: SchemaFieldMeta | null,
+  siblingValues: SiblingValue[],
+  documentType: string | undefined,
+  documentTitle: string | undefined,
+): string | null {
+  if (!fieldMeta) return null;
+
+  const parts: string[] = [];
+
+  // Start with the field description if available — it often contains
+  // editor-authored instructions like "Product lifestyle photo, square format"
+  if (fieldMeta.description) {
+    parts.push(fieldMeta.description);
+  } else {
+    // Fall back to field title
+    parts.push(fieldMeta.title);
+  }
+
+  // Add document context
+  if (documentTitle) {
+    const typeLabel = documentType
+      ? documentType.replace(/([A-Z])/g, ' $1').toLowerCase().trim()
+      : 'content';
+    parts.push(`for ${typeLabel}: "${documentTitle}"`);
+  }
+
+  // Add select sibling values for richer context
+  const category = siblingValues.find((s) => s.fieldName === 'category');
+  const tags = siblingValues.find((s) => s.fieldName === 'tags');
+  const style = siblingValues.find(
+    (s) => s.fieldName === 'style' || s.fieldName === 'theme' || s.fieldName === 'mood',
+  );
+  const color = siblingValues.find(
+    (s) => s.fieldName === 'color' || s.fieldName === 'colours' || s.fieldName === 'colors',
+  );
+
+  if (category) parts.push(`category: ${category.value}`);
+  if (style) parts.push(`style: ${style.value}`);
+  if (color) parts.push(`colors: ${color.value}`);
+  if (tags) parts.push(`keywords: ${tags.value}`);
+
+  return parts.join(', ');
+}

--- a/src/lib/useTypeahead.ts
+++ b/src/lib/useTypeahead.ts
@@ -1,0 +1,154 @@
+/**
+ * Debounced typeahead hook for brief suggestions.
+ *
+ * Calls `client.content.brief()` as the user types, with a 500ms debounce.
+ * Results are cached per (prefix + context) key to avoid redundant API calls.
+ *
+ * Closes #65.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { LaminaClient, ContentConcept, ContentBriefParams } from '@uselamina/sdk';
+
+const DEBOUNCE_MS = 500;
+/** Minimum characters before triggering typeahead. */
+const MIN_LENGTH = 8;
+
+interface TypeaheadContext {
+  modality?: string;
+  brandProfileId?: string;
+  documentType?: string;
+  documentTitle?: string;
+  fieldName?: string;
+  documentExcerpt?: string;
+}
+
+export interface TypeaheadResult {
+  /** Current suggestions. */
+  suggestions: ContentConcept[];
+  /** Whether a fetch is in flight. */
+  loading: boolean;
+  /** Clear all suggestions. */
+  clear: () => void;
+}
+
+/**
+ * Debounced typeahead hook.
+ *
+ * @param client - The LaminaClient instance.
+ * @param brief - Current value of the brief textarea.
+ * @param context - Document/field context for relevance.
+ * @param enabled - Pass `false` to disable (e.g. while generating).
+ */
+export function useTypeahead(
+  client: LaminaClient,
+  brief: string,
+  context: TypeaheadContext,
+  enabled: boolean,
+): TypeaheadResult {
+  const [suggestions, setSuggestions] = useState<ContentConcept[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // In-memory cache keyed on brief prefix + context.
+  const cacheRef = useRef<Map<string, ContentConcept[]>>(new Map());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const buildCacheKey = useCallback(
+    (text: string) =>
+      `${text.trim().toLowerCase().substring(0, 60)}::${context.documentType ?? ''}:${context.fieldName ?? ''}:${context.brandProfileId ?? ''}`,
+    [context.documentType, context.fieldName, context.brandProfileId],
+  );
+
+  const clear = useCallback(() => {
+    setSuggestions([]);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    abortRef.current?.abort();
+  }, []);
+
+  useEffect(() => {
+    // Clear previous timer
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    // Don't fetch if disabled, too short, or empty
+    if (!enabled || brief.trim().length < MIN_LENGTH) {
+      setSuggestions([]);
+      return;
+    }
+
+    const cacheKey = buildCacheKey(brief);
+    const cached = cacheRef.current.get(cacheKey);
+    if (cached) {
+      setSuggestions(cached);
+      return;
+    }
+
+    // Debounce the API call
+    timerRef.current = setTimeout(async () => {
+      abortRef.current?.abort();
+      const abort = new AbortController();
+      abortRef.current = abort;
+
+      setLoading(true);
+      try {
+        const goalParts = [brief.trim()];
+        if (context.documentTitle) {
+          goalParts.push(`for ${context.documentType ?? 'content'}: ${context.documentTitle}`);
+        }
+        if (context.documentExcerpt) {
+          goalParts.push(context.documentExcerpt);
+        }
+
+        const params: ContentBriefParams = {
+          goal: goalParts.join(' — '),
+          modality: context.modality || 'image',
+          count: 3,
+          ...(context.brandProfileId ? { brandProfileId: context.brandProfileId } : {}),
+        };
+
+        const result = await client.content.brief(params);
+        if (abort.signal.aborted) return;
+
+        const concepts = result.data?.concepts ?? [];
+        cacheRef.current.set(cacheKey, concepts);
+
+        // Limit cache size
+        if (cacheRef.current.size > 50) {
+          const firstKey = cacheRef.current.keys().next().value;
+          if (firstKey !== undefined) {
+            cacheRef.current.delete(firstKey);
+          }
+        }
+
+        setSuggestions(concepts);
+      } catch {
+        if (!abort.signal.aborted) setSuggestions([]);
+      } finally {
+        if (!abort.signal.aborted) setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [brief, enabled, client, context.modality, context.brandProfileId, context.documentType, context.documentTitle, context.fieldName, context.documentExcerpt, buildCacheKey]);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return { suggestions, loading, clear };
+}


### PR DESCRIPTION
## Summary

- **Auto-optimize brief (#66):** "Enhance brief" toggle rewrites rough user prompts via `content.brief()` before generation. Shows enhanced preview. Skips if brief came from an AI suggestion.
- **Typeahead suggestions (#65):** Debounced (500ms) completions appear as clickable chips below the textarea as the user types (8+ chars). Cached per prefix + context.
- **Schema-aware templates (#67):** Reads Sanity schema at runtime via `useSchema()` — field descriptions, sibling values (title, category, tags, style, color) — to generate richer prompts and enrich API metadata.
- **Bulk generation (#70):** Rewrites "Generate all media" document action into a 3-phase workflow: review editable briefs per empty field → parallel generation (concurrency 3) → approve/reject per field → patch approved assets into the document.

### New files
| File | Purpose |
|------|---------|
| `src/lib/briefEnhancer.ts` | `enhanceBrief()` + `buildSilentEnrichment()` |
| `src/lib/useTypeahead.ts` | Debounced typeahead hook with in-memory cache |
| `src/lib/schemaContext.ts` | `getFieldMeta()`, `extractSiblingContext()`, `buildSchemaAwarePrompt()` |

### Modified files
| File | Changes |
|------|---------|
| `src/components/GenerateDialog.tsx` | Integrates all 3 prompt features: enhance toggle + preview, typeahead chips, schema-aware suggestion chip |
| `src/actions/generateAllAction.tsx` | Full rewrite from passive field list to bulk generation workflow |

## Test plan

- [ ] Open GenerateDialog from an image field — verify "Enhance brief" checkbox is visible and on by default
- [ ] Type 8+ characters in the brief — verify typeahead suggestion chips appear after ~500ms
- [ ] Click an AI suggestion chip — verify it populates the brief and marks it as AI-sourced (no re-enhancement)
- [ ] Open dialog on a document with rich schema (description on fields, tags/category filled) — verify "From your schema" suggestion appears
- [ ] Generate with enhance enabled — verify enhanced brief preview card appears during generation
- [ ] Generate with enhance disabled — verify original brief is used as-is
- [ ] Use "Generate all media" document action on a document with 2+ empty image fields — verify review phase shows editable briefs
- [ ] Click "Generate N assets" — verify parallel generation with progress indicators
- [ ] In results phase, approve some and reject others — verify "Save N assets" patches only approved ones
- [ ] Verify clean `npm run build` with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)