### PR TITLE
Headless API, CLI, webhook handler, and comprehensive docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,56 @@
 # sanity-plugin-lamina
 
-Sanity Studio plugin that lets content editors generate and manage media assets with Lamina directly inside Sanity Studio.
+Sanity plugin for generating and managing media assets with Lamina — Studio UI, headless API, CLI, and webhooks.
 
 **GitHub issue:** cirbuk/react-flow-integration#807
 
 ## What this plugin does
 
-Three Sanity Studio extension points:
-
+### Studio plugin (`sanity-plugin-lamina`)
 1. **Asset Source** — "Generate with Lamina" appears in every image/file field dropdown. User types a brief, Lamina generates media, user clicks "Use this" to save it as a Sanity asset.
 2. **Studio Tool** — "Lamina" tab in top Studio nav. Embeds the full Lamina editor via iframe. Outputs are saved back to Sanity via postMessage bridge.
-3. **Document Action** — "Edit in Lamina" appears in the document action bar. Detects Lamina-sourced assets (via `source.name === 'lamina'` metadata) and opens the original run for editing.
+3. **Document Actions** — "Edit in Lamina" and "Generate all media" in the document action bar.
+
+### Headless API (`sanity-plugin-lamina/headless`)
+Programmatic content generation — `createLaminaSanityClient()` wraps both SDKs into high-level operations: `generate()`, `generateForDocument()`, `fillEmptyMedia()`, `uploadToSanity()`, `scoreAssets()`, and the intelligence API.
+
+### Webhook handler (`sanity-plugin-lamina/webhooks`)
+`createLaminaWebhookHandler()` — auto-generates media on Sanity document events. Deploy as serverless function.
+
+### CLI (`npx sanity-lamina`)
+Terminal-based bulk generation, document filling, asset scoring, app listing, and credit checking.
 
 ## Architecture
 
 ```
 src/
-├── index.ts                          # Public exports
-├── plugin.tsx                        # definePlugin entry — registers all 3 surfaces
+├── index.ts                          # Studio plugin public exports (React)
+├── plugin.tsx                        # definePlugin entry — registers all Studio surfaces
 ├── types.ts                          # LaminaPluginOptions, GenerationState, GeneratedOutput
-├── lib/
-│   └── LaminaContext.tsx             # React context providing LaminaClient from @uselamina/sdk
+├── lib/                              # Shared pure-TS utilities (no React dep)
+│   ├── LaminaContext.tsx             # React context providing LaminaClient from @uselamina/sdk
+│   ├── briefEnhancer.ts             # Brief enhancement + silent enrichment
+│   ├── useTypeahead.ts              # Debounced typeahead hook (React)
+│   ├── schemaContext.ts             # Schema introspection for field meta + siblings
+│   ├── aspectRatio.ts               # Field-name-to-ratio detection
+│   ├── appRouting.ts                # App selection persistence
+│   └── recentBriefs.ts              # Brief history tracking
 ├── components/
 │   ├── LaminaAssetSource.tsx         # AssetSource definition { name, title, icon, component }
-│   └── GenerateDialog.tsx            # The generation UI: brief → generate → poll → preview → select
+│   └── GenerateDialog.tsx            # Generation UI with prompt intelligence
 ├── tool/
-│   └── LaminaTool.tsx               # Studio tool: iframe embed + postMessage bridge + save-to-Sanity
-└── actions/
-    └── regenerateAction.tsx          # Document action: finds Lamina assets, opens run URL
+│   └── LaminaTool.tsx               # Studio tool: iframe embed + postMessage bridge
+├── actions/
+│   ├── regenerateAction.tsx          # Document action: finds Lamina assets, opens run URL
+│   └── generateAllAction.tsx         # Bulk generation document action (3-phase workflow)
+├── headless/                         # Headless API (no React)
+│   ├── index.ts                      # Public exports
+│   ├── client.ts                     # createLaminaSanityClient factory + implementation
+│   └── types.ts                      # Headless-specific types
+├── webhooks/
+│   └── index.ts                      # createLaminaWebhookHandler factory
+└── cli/
+    └── index.ts                      # CLI entry point (bin: sanity-lamina)
 ```
 
 ## Key dependencies

--- a/README.md
+++ b/README.md
@@ -1,31 +1,65 @@
-# Lamina Video & Image Creator for Sanity
+# Lamina for Sanity
 
-Sanity Studio plugin that lets content editors generate and manage media assets with [Lamina](https://uselamina.ai) directly inside Sanity Studio.
-
-![Lamina Plugin Demo](screenshots/lamina-plugin-demo.gif)
-
-## Features
-
-- **Asset Source** -- "Generate with Lamina" appears in every image/file field dropdown. Type a brief, Lamina generates media, click "Use this" to save it as a Sanity asset.
-- **Context-Aware** -- Auto-suggests briefs from document title, field name, and schema type. No prompt engineering needed.
-- **Aspect Ratio Detection** -- Detects the target aspect ratio from field name (e.g. heroImage -> 16:9, ogImage -> 16:9) and passes it to the API.
-- **Studio Tool** -- "Lamina" tab in top Studio nav with embedded Lamina editor and a filterable asset browser.
-- **From Library** -- Reuse previously generated Lamina assets directly from the Generate dialog.
-- **Output Presets** -- Configure per-field generation presets (aspect ratio, modality, platform) via plugin config.
-- **Batch Generation** -- Generate 2-5 variants at once with the "Generate variants" toggle.
-- **App Picker** -- Browse or AI-match Lamina apps before generating, with credit cost estimates.
-- **Smart History** -- Recently used prompts appear as suggestion chips. App selections are remembered per field type.
-- **Quality Feedback** -- Rate outputs after saving to improve future generation quality.
-- **Brand & Campaign** -- Select brand profiles and campaigns when available to keep outputs on-brand.
-- **OAuth Support** -- Optional per-user authentication alongside team-level API keys.
-
-## Installation
+Generate and manage media assets with [Lamina](https://uselamina.ai) in Sanity -- as a Studio UI plugin, a headless Node.js API, a CLI tool, or a webhook-driven automation.
 
 ```bash
 npm install sanity-plugin-lamina
 ```
 
-## Configuration
+## Two modes, one package
+
+| Mode | Import | Requires React? | Use case |
+|------|--------|-----------------|----------|
+| **Studio plugin** | `sanity-plugin-lamina` | Yes | Editors generating media inside Sanity Studio |
+| **Headless API** | `sanity-plugin-lamina/headless` | No | Scripts, pipelines, migrations, serverless functions |
+| **Webhook handler** | `sanity-plugin-lamina/webhooks` | No | Auto-generate media on document events |
+| **CLI** | `npx sanity-lamina` | No | Terminal-based bulk generation and scoring |
+
+---
+
+## Table of contents
+
+- [Studio plugin](#studio-plugin)
+  - [Quick start](#quick-start)
+  - [Configuration options](#configuration-options)
+  - [Asset source (Generate Dialog)](#asset-source)
+  - [Prompt intelligence](#prompt-intelligence)
+  - [Studio tool](#studio-tool)
+  - [Document actions](#document-actions)
+  - [Field-level input](#field-level-input)
+  - [OAuth](#oauth)
+- [Headless API](#headless-api)
+  - [Setup](#headless-setup)
+  - [Generate for a document](#generate-for-a-document)
+  - [Bulk fill empty media](#bulk-fill-empty-media)
+  - [Standalone generation](#standalone-generation)
+  - [Upload to Sanity](#upload-to-sanity)
+  - [Score assets](#score-assets)
+  - [Intelligence API](#intelligence-api)
+- [CLI reference](#cli-reference)
+  - [generate](#cli-generate)
+  - [fill-document](#cli-fill-document)
+  - [score](#cli-score)
+  - [apps](#cli-apps)
+  - [credits](#cli-credits)
+- [Webhook handler](#webhook-handler)
+  - [Setup with Vercel](#webhook-vercel)
+  - [Trigger configuration](#webhook-triggers)
+  - [Template syntax](#template-syntax)
+- [Recipes](#recipes)
+  - [Content migration with media generation](#recipe-migration)
+  - [CI pipeline: generate on publish](#recipe-ci)
+  - [Multi-brand content generation](#recipe-multi-brand)
+  - [Quality gate: score before publish](#recipe-quality-gate)
+- [Architecture](#architecture)
+- [Development](#development)
+- [License](#license)
+
+---
+
+## Studio plugin
+
+### Quick start
 
 ```ts
 // sanity.config.ts
@@ -33,7 +67,6 @@ import { defineConfig } from 'sanity'
 import { laminaPlugin } from 'sanity-plugin-lamina'
 
 export default defineConfig({
-  // ...your config
   plugins: [
     laminaPlugin({
       apiKey: process.env.SANITY_STUDIO_LAMINA_API_KEY!,
@@ -42,18 +75,83 @@ export default defineConfig({
 })
 ```
 
-### Options
+This registers three surfaces in your Studio:
+
+1. **Asset source** -- "Generate with Lamina" in every image/file field picker
+2. **Studio tool** -- "Lamina" tab in the top nav with embedded editor + asset browser
+3. **Document actions** -- "Edit in Lamina" and "Generate all media" in the action bar
+
+### Configuration options
 
 | Option | Type | Default | Description |
-|---|---|---|---|
+|--------|------|---------|-------------|
 | `apiKey` | `string` | -- | Lamina API key (team-level). Required unless OAuth is configured. |
 | `baseUrl` | `string` | `https://app.uselamina.ai` | Lamina API base URL. |
 | `oauth` | `{ clientId, redirectUri?, storageKey? }` | -- | OAuth config for per-user authentication. |
 | `enableTool` | `boolean` | `true` | Register the Lamina Editor as a Studio tool. |
-| `enableDocumentAction` | `boolean` | `true` | Register the "Edit in Lamina" document action. |
-| `webhookUrl` | `string` | -- | Webhook URL for generation completion events (alternative to polling). |
+| `enableDocumentAction` | `boolean` | `true` | Register document actions. |
+| `webhookUrl` | `string` | -- | Webhook URL for generation completion events. |
+| `presets` | `Record<string, LaminaPreset>` | Built-in defaults | Per-field generation presets. |
 
-### OAuth Configuration
+#### Presets
+
+Map field names to generation parameters. Custom presets override the built-in defaults (`ogImage`, `socialImage`, `storyImage`, `thumbnail`, `avatar`).
+
+```ts
+laminaPlugin({
+  apiKey: '...',
+  presets: {
+    heroImage: { aspectRatio: '16:9', modality: 'image' },
+    productVideo: { aspectRatio: '9:16', modality: 'video', platform: 'instagram' },
+    logo: { aspectRatio: '1:1', modality: 'image', appId: 'app_logo_generator' },
+  },
+})
+```
+
+### Asset source
+
+Click "Generate with Lamina" in any image or file field to open the Generate Dialog:
+
+1. **Describe what you need** -- type a brief or pick from AI suggestions
+2. **Select output type** -- image, video, or auto-detect
+3. **Optionally pick an app** -- browse or AI-match Lamina apps with cost estimates
+4. **Generate** -- the plugin calls the Lamina API and shows real-time progress
+5. **Use this** -- saves the output as a Sanity asset with Lamina source metadata
+
+The "From library" tab lets you reuse previously generated Lamina assets with search, type filtering, and document-scoped views.
+
+### Prompt intelligence
+
+The Generate Dialog includes three intelligence features that improve prompt quality:
+
+**Auto-enhance brief** -- An "Enhance brief" toggle (on by default) rewrites your rough prompt into an optimized generation prompt before sending it to the API. Shows a preview of the enhanced version during generation.
+
+**Typeahead suggestions** -- As you type (8+ characters), debounced suggestions appear as clickable chips below the textarea. Cached per context to avoid redundant API calls.
+
+**Schema-aware templates** -- Reads your Sanity schema at runtime via `useSchema()` to generate context-rich prompts. If your schema has field descriptions, sibling fields like `category` or `tags`, or validation rules, the plugin uses them to build better prompts automatically.
+
+### Studio tool
+
+The "Lamina" tab in the top nav provides:
+
+- **Editor** -- Embedded Lamina editor via iframe. Assets generated here are saved to Sanity via postMessage bridge.
+- **Assets** -- Browse all Lamina-generated assets with thumbnails, search, type filtering, and infinite scroll.
+
+### Document actions
+
+**Edit in Lamina** -- Finds all image/file fields with Lamina source metadata and opens the original run for editing.
+
+**Generate all media** -- Scans the document for empty image/file fields, builds contextual briefs for each, and runs parallel generations. Presents a 3-phase workflow:
+
+1. **Review** -- Editable briefs per field, auto-generated from schema context
+2. **Generate** -- Parallel generation with per-field progress indicators
+3. **Results** -- Approve/reject per field, then save approved assets to the document
+
+### Field-level input
+
+Every image/file field gets an inline "Edit in Lamina" button that detects Lamina-sourced assets and opens the original run.
+
+### OAuth
 
 For per-user authentication instead of (or alongside) a team API key:
 
@@ -61,35 +159,556 @@ For per-user authentication instead of (or alongside) a team API key:
 laminaPlugin({
   oauth: {
     clientId: 'your-lamina-oauth-client-id',
-    redirectUri: 'https://your-studio.sanity.studio/lamina/callback', // optional
+    redirectUri: 'https://your-studio.sanity.studio/lamina/callback',
   },
 })
 ```
 
-Users without a team API key will see a "Sign in with Lamina" button.
+Users without a team API key see a "Sign in with Lamina" button.
 
-## How It Works
+---
 
-### Asset Source (Generate Dialog)
+## Headless API
 
-1. Click "Generate with Lamina" in any image or file field
-2. Describe what you need in the brief field
-3. Optionally select a specific Lamina app or let auto-detect choose
-4. Click Generate -- the plugin calls `content.create()` and polls for completion
-5. Preview generated outputs and click "Use this" to save as a Sanity asset
+The headless API wraps `@uselamina/sdk` and `@sanity/client` into high-level operations for programmatic content generation. No React or browser required.
 
-Generated assets are tagged with `source.name: 'lamina'` and include the run ID and URL for traceability.
+<a id="headless-setup"></a>
 
-### Studio Tool
+### Setup
 
-The Lamina tab in the top nav provides:
+```ts
+import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'
 
-- **Editor tab** -- Embedded Lamina editor via iframe. Assets generated here are automatically saved to Sanity via postMessage bridge.
-- **Assets tab** -- Browse all Lamina-generated assets in your Sanity dataset with thumbnails, filenames, and links to the original Lamina run. Filter by type (images/videos), search by filename, and scroll to load more.
+const lamina = createLaminaSanityClient({
+  laminaApiKey: process.env.LAMINA_API_KEY,
+  sanityProjectId: 'your-project-id',
+  sanityDataset: 'production',
+  sanityToken: process.env.SANITY_TOKEN,
+})
+```
 
-### Document Action
+Or pass a pre-configured Sanity client:
 
-The "Edit in Lamina" action uses schema-aware discovery to find all image/file fields in a document (at any nesting depth), checks if their assets have Lamina source metadata, and opens the original run for editing.
+```ts
+import { createClient } from '@sanity/client'
+import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'
+
+const sanityClient = createClient({
+  projectId: 'abc123',
+  dataset: 'production',
+  token: process.env.SANITY_TOKEN,
+  apiVersion: '2024-01-01',
+  useCdn: false,
+})
+
+const lamina = createLaminaSanityClient({
+  laminaApiKey: process.env.LAMINA_API_KEY,
+  sanityClient,
+})
+```
+
+#### Configuration
+
+| Option | Env var fallback | Description |
+|--------|-----------------|-------------|
+| `laminaApiKey` | `LAMINA_API_KEY` | Lamina API key |
+| `laminaBaseUrl` | -- | API base URL (default: `https://app.uselamina.ai`) |
+| `sanityProjectId` | `SANITY_PROJECT_ID` | Sanity project ID |
+| `sanityDataset` | `SANITY_DATASET` | Dataset (default: `production`) |
+| `sanityToken` | `SANITY_TOKEN` | Sanity API token with write access |
+| `sanityClient` | -- | Pre-configured `@sanity/client` instance |
+| `defaultBrandProfileId` | -- | Default brand profile for all generations |
+| `defaultCampaignId` | -- | Default campaign for all generations |
+| `webhookUrl` | -- | Webhook URL for completion notifications |
+
+### Generate for a document
+
+The highest-level operation. Generates media for a specific field on a document, uploads to Sanity, and patches the document -- all in one call.
+
+```ts
+const result = await lamina.generateForDocument('product-123', 'heroImage', {
+  brief: 'Lifestyle product photo on marble surface',
+  // Optional overrides:
+  modality: 'image',
+  aspectRatio: '16:9',
+  brandProfileId: 'bp_123',
+})
+
+console.log(result.sanityAssetId)  // 'image-abc123-1200x630-png'
+console.log(result.patched)        // true
+console.log(result.finalBrief)     // The enhanced brief that was actually sent
+```
+
+If you omit the `brief`, one is auto-generated from the document's title, type, and field name.
+
+### Bulk fill empty media
+
+The workhorse for content operations at scale. Finds documents via GROQ, identifies empty media fields, generates assets, and patches documents.
+
+```ts
+const result = await lamina.fillEmptyMedia({
+  query: '*[_type == "product" && !defined(mainImage)]{ _id, _type, title, mainImage, category }',
+  fieldMapping: {
+    mainImage: 'Product photo of {{title}}, {{category}} category',
+  },
+  concurrency: 5,
+  enhance: true,
+  brandProfileId: 'bp_123',
+  onProgress: (event) => {
+    console.log(`${event.documentId} / ${event.fieldName}: ${event.status}`)
+  },
+})
+
+console.log(`${result.fieldsGenerated} generated, ${result.fieldsFailed} failed`)
+```
+
+#### Dry run
+
+Preview what would happen without generating or patching:
+
+```ts
+const result = await lamina.fillEmptyMedia({
+  query: '*[_type == "product" && !defined(mainImage)]',
+  fieldMapping: { mainImage: 'Product photo: {{title}}' },
+  dryRun: true,
+})
+
+for (const doc of result.results) {
+  for (const field of doc.fields) {
+    console.log(`Would generate: ${field.brief}`)
+  }
+}
+```
+
+### Standalone generation
+
+Generate content without uploading to Sanity. Useful for previewing, testing, or custom upload flows.
+
+```ts
+const result = await lamina.generate({
+  brief: 'Social media banner for summer sale',
+  modality: 'image',
+  aspectRatio: '16:9',
+  enhance: true,
+})
+
+for (const output of result.outputs) {
+  console.log(`${output.type}: ${output.url} (${output.dimensions?.width}x${output.dimensions?.height})`)
+}
+```
+
+### Upload to Sanity
+
+Upload a URL to Sanity as an asset and optionally patch a document field.
+
+```ts
+const uploaded = await lamina.uploadToSanity({
+  url: 'https://cdn.uselamina.ai/outputs/abc123.png',
+  type: 'image',
+  filename: 'hero-image',
+  description: 'Product lifestyle photo',
+  documentId: 'product-123',
+  fieldName: 'heroImage',
+})
+
+console.log(uploaded.assetId)  // 'image-abc123-...'
+console.log(uploaded.patched)  // true
+```
+
+### Score assets
+
+Score existing Lamina-generated assets for quality and relevance.
+
+```ts
+const scores = await lamina.scoreAssets({
+  query: '*[_type == "sanity.imageAsset" && source.name == "lamina"][0..49]{ _id, url, description }',
+  platform: 'instagram',
+})
+
+for (const s of scores) {
+  console.log(`${s.assetId}: score ${s.score} — "${s.brief}"`)
+}
+```
+
+### Intelligence API
+
+Access Lamina's intelligence features programmatically.
+
+```ts
+// Content trends
+const trends = await lamina.intelligence.trends({
+  category: 'fashion',
+  platform: 'instagram',
+  windowDays: 30,
+})
+
+// Performance prediction
+const prediction = await lamina.intelligence.predict({
+  concept: 'Minimalist product flat-lay with neutral tones',
+  platform: 'instagram',
+  modality: 'image',
+})
+
+// AI recommendations
+const recs = await lamina.intelligence.recommendations({
+  brandProfileId: 'bp_123',
+  platform: 'instagram',
+  limit: 5,
+})
+
+// Brand context
+const brand = await lamina.intelligence.getBrandContext('bp_123')
+```
+
+### Accessing underlying clients
+
+For advanced use cases, access the raw SDK clients directly:
+
+```ts
+// Lamina SDK client
+const apps = await lamina.lamina.apps.list()
+
+// Sanity client
+const docs = await lamina.sanity.fetch('*[_type == "product"][0..9]')
+```
+
+---
+
+## CLI reference
+
+```bash
+npx sanity-lamina --help
+```
+
+All commands read configuration from environment variables or CLI flags:
+
+| Flag | Env var | Description |
+|------|---------|-------------|
+| `--api-key` | `LAMINA_API_KEY` | Lamina API key |
+| `--project` | `SANITY_PROJECT_ID` | Sanity project ID |
+| `--dataset` | `SANITY_DATASET` | Sanity dataset (default: `production`) |
+| `--token` | `SANITY_TOKEN` | Sanity API token |
+| `--json` | -- | Output as JSON (for piping) |
+
+<a id="cli-generate"></a>
+
+### `generate`
+
+Bulk generate media for documents matching a GROQ query.
+
+```bash
+npx sanity-lamina generate \
+  --query '*[_type == "product" && !defined(heroImage)]' \
+  --field heroImage \
+  --brief 'Product lifestyle photo for {{title}}' \
+  --concurrency 5
+
+# Dry run -- see what would be generated
+npx sanity-lamina generate \
+  --query '*[_type == "product" && !defined(heroImage)]' \
+  --field heroImage \
+  --brief 'Product photo: {{title}}' \
+  --dry-run
+
+# With brand profile
+npx sanity-lamina generate \
+  --query '*[_type == "blogPost" && !defined(coverImage)]' \
+  --field coverImage \
+  --brief 'Blog cover: {{title}}' \
+  --brand-profile bp_123
+```
+
+<a id="cli-fill-document"></a>
+
+### `fill-document`
+
+Fill all empty media fields on a single document.
+
+```bash
+npx sanity-lamina fill-document product-123
+npx sanity-lamina fill-document product-123 --brand-profile bp_123 --no-enhance
+```
+
+<a id="cli-score"></a>
+
+### `score`
+
+Score existing Lamina-generated assets.
+
+```bash
+npx sanity-lamina score
+npx sanity-lamina score --limit 50 --platform instagram
+npx sanity-lamina score --json | jq '.[] | select(.score < 5)'
+```
+
+<a id="cli-apps"></a>
+
+### `apps`
+
+List available Lamina apps.
+
+```bash
+npx sanity-lamina apps
+npx sanity-lamina apps --json
+```
+
+<a id="cli-credits"></a>
+
+### `credits`
+
+Check credit balance.
+
+```bash
+npx sanity-lamina credits
+```
+
+---
+
+## Webhook handler
+
+Auto-generate media when documents are created or updated in Sanity.
+
+<a id="webhook-vercel"></a>
+
+### Setup with Vercel
+
+```ts
+// api/lamina-webhook.ts
+import { createLaminaWebhookHandler } from 'sanity-plugin-lamina/webhooks'
+
+export default createLaminaWebhookHandler({
+  laminaApiKey: process.env.LAMINA_API_KEY!,
+  sanityProjectId: process.env.SANITY_PROJECT_ID!,
+  sanityToken: process.env.SANITY_TOKEN!,
+  sanityWebhookSecret: process.env.SANITY_WEBHOOK_SECRET,
+
+  triggers: [
+    {
+      filter: '_type == "product"',
+      fields: {
+        heroImage: 'Product lifestyle photo for {{title}}',
+        thumbnail: 'Product thumbnail, square crop, {{title}}',
+        ogImage: 'Social share image for {{title}}',
+      },
+      onlyIfEmpty: true,
+      enhance: true,
+      brandProfileId: 'bp_123',
+    },
+    {
+      filter: '_type == "blogPost"',
+      fields: {
+        coverImage: 'Blog cover illustration: {{title}}',
+      },
+      onlyIfEmpty: true,
+    },
+  ],
+
+  onGenerated: (documentId, fieldName) => {
+    console.log(`Generated ${fieldName} for ${documentId}`)
+  },
+  onError: (documentId, fieldName, error) => {
+    console.error(`Failed ${fieldName} for ${documentId}: ${error}`)
+  },
+})
+```
+
+Then configure a Sanity webhook pointing to your function URL:
+
+1. Go to **sanity.io/manage** > your project > **API** > **Webhooks**
+2. Create a new webhook with:
+   - **URL**: `https://your-site.vercel.app/api/lamina-webhook`
+   - **Trigger on**: Create, Update
+   - **Filter**: `_type in ["product", "blogPost"]`
+   - **Secret**: Generate one and set it as `SANITY_WEBHOOK_SECRET`
+   - **Projection**: `{ _id, _type, title, ... }` (include fields referenced in your templates)
+
+<a id="webhook-triggers"></a>
+
+### Trigger configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `filter` | `string` | -- | GROQ-like filter expression (e.g. `_type == "product"`) |
+| `fields` | `Record<string, string>` | -- | Field name to brief template mapping |
+| `onlyIfEmpty` | `boolean` | `true` | Only generate if the field has no asset |
+| `enhance` | `boolean` | `true` | Auto-enhance briefs before generation |
+| `brandProfileId` | `string` | -- | Brand profile for this trigger |
+| `campaignId` | `string` | -- | Campaign for this trigger |
+
+<a id="template-syntax"></a>
+
+### Template syntax
+
+Brief strings support `{{fieldName}}` placeholders resolved from the document:
+
+```
+'Product photo of {{title}}'           -> 'Product photo of Nike Air Max 90'
+'{{category}} product on {{color}}'    -> 'Running product on white'
+'Blog cover: {{title}}'               -> 'Blog cover: How to Choose Running Shoes'
+```
+
+Nested fields use dot notation: `{{category.title}}`.
+
+---
+
+## Recipes
+
+<a id="recipe-migration"></a>
+
+### Content migration with media generation
+
+Generate images for every product imported from a CSV:
+
+```ts
+import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'
+import { createClient } from '@sanity/client'
+import { parse } from 'csv-parse/sync'
+import { readFileSync } from 'fs'
+
+const lamina = createLaminaSanityClient({
+  laminaApiKey: process.env.LAMINA_API_KEY,
+  sanityProjectId: 'abc123',
+  sanityToken: process.env.SANITY_TOKEN,
+  defaultBrandProfileId: 'bp_brand',
+})
+
+const sanity = lamina.sanity
+const rows = parse(readFileSync('products.csv'), { columns: true })
+
+for (const row of rows) {
+  // Create the document
+  const doc = await sanity.create({
+    _type: 'product',
+    title: row.name,
+    price: Number(row.price),
+    category: row.category,
+  })
+
+  // Generate and attach hero image
+  await lamina.generateForDocument(doc._id, 'heroImage', {
+    brief: `${row.category} product photo: ${row.name}, lifestyle setting`,
+    aspectRatio: '16:9',
+  })
+
+  // Generate thumbnail
+  await lamina.generateForDocument(doc._id, 'thumbnail', {
+    brief: `Product thumbnail: ${row.name}, clean white background`,
+    aspectRatio: '1:1',
+  })
+
+  console.log(`Created ${doc._id} with media`)
+}
+```
+
+<a id="recipe-ci"></a>
+
+### CI pipeline: generate on publish
+
+Run in a GitHub Action or similar:
+
+```bash
+# Find all blog posts published in the last hour without cover images
+npx sanity-lamina generate \
+  --query '*[_type == "blogPost" && !defined(coverImage) && dateTime(_updatedAt) > dateTime(now()) - 60*60]' \
+  --field coverImage \
+  --brief 'Blog header illustration: {{title}}' \
+  --concurrency 3
+```
+
+<a id="recipe-multi-brand"></a>
+
+### Multi-brand content generation
+
+```ts
+import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'
+
+const brands = [
+  { profileId: 'bp_brand_a', query: '*[_type == "product" && brand == "A"]' },
+  { profileId: 'bp_brand_b', query: '*[_type == "product" && brand == "B"]' },
+]
+
+for (const brand of brands) {
+  const lamina = createLaminaSanityClient({
+    laminaApiKey: process.env.LAMINA_API_KEY,
+    sanityProjectId: 'abc123',
+    sanityToken: process.env.SANITY_TOKEN,
+    defaultBrandProfileId: brand.profileId,
+  })
+
+  const result = await lamina.fillEmptyMedia({
+    query: `${brand.query} && !defined(heroImage)`,
+    fieldMapping: { heroImage: 'Brand product photo: {{title}}' },
+    concurrency: 5,
+  })
+
+  console.log(`Brand ${brand.profileId}: ${result.fieldsGenerated} generated`)
+}
+```
+
+<a id="recipe-quality-gate"></a>
+
+### Quality gate: score before publish
+
+```ts
+import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'
+
+const lamina = createLaminaSanityClient({ /* ... */ })
+
+// Score all assets for a document before publishing
+const scores = await lamina.scoreAssets({
+  query: `*[_type == "sanity.imageAsset" && source.name == "lamina" && source.documentId == "product-123"]{ _id, url, description }`,
+  platform: 'instagram',
+})
+
+const lowScores = scores.filter((s) => s.score !== null && s.score < 5)
+if (lowScores.length > 0) {
+  console.warn(`${lowScores.length} assets scored below threshold -- regenerating`)
+  for (const asset of lowScores) {
+    // Regenerate with the original brief
+    await lamina.generateForDocument('product-123', 'heroImage', {
+      brief: asset.brief || undefined,
+    })
+  }
+}
+```
+
+---
+
+## Architecture
+
+```
+sanity-plugin-lamina
+|
+|-- Studio plugin (import from "sanity-plugin-lamina")
+|   |-- Asset Source (GenerateDialog)
+|   |-- Studio Tool (LaminaTool)
+|   |-- Document Actions (regenerate, generateAll)
+|   |-- Field Input (LaminaImageInput)
+|   \-- React context (LaminaProvider / useLamina)
+|
+|-- Headless API (import from "sanity-plugin-lamina/headless")
+|   |-- createLaminaSanityClient()
+|   |-- generate(), generateForDocument(), fillEmptyMedia()
+|   |-- uploadToSanity(), scoreAssets()
+|   \-- intelligence.trends/predict/recommendations/getBrandContext
+|
+|-- Webhook handler (import from "sanity-plugin-lamina/webhooks")
+|   \-- createLaminaWebhookHandler()
+|
+|-- CLI (npx sanity-lamina)
+|   \-- generate, fill-document, score, apps, credits
+|
+\-- Shared lib (used by all layers, no React dependency)
+    |-- briefEnhancer.ts    -- Brief enhancement + silent enrichment
+    |-- schemaContext.ts     -- Schema introspection utilities
+    |-- aspectRatio.ts      -- Field-name-to-ratio detection
+    |-- appRouting.ts       -- App selection persistence
+    \-- recentBriefs.ts     -- Brief history tracking
+```
+
+The Studio plugin depends on React and `@sanity/ui`. The headless layer, webhook handler, and CLI only depend on `@uselamina/sdk` and `@sanity/client` -- no React required.
+
+---
 
 ## Development
 
@@ -99,36 +718,40 @@ npm run build     # tsc -> dist/
 npm run dev       # tsc --watch
 ```
 
-### Local Testing
+### Local testing (Studio plugin)
 
 ```bash
 # In this repo:
 npm run dev
 
 # In a Sanity Studio project:
-# Add to package.json: "sanity-plugin-lamina": "file:../sanity-lamina"
-# Then add to sanity.config.ts as shown above
+# package.json: "sanity-plugin-lamina": "file:../sanity-lamina"
+# sanity.config.ts: plugins: [laminaPlugin({ apiKey: '...' })]
 ```
 
-## Architecture
+### Local testing (headless / CLI)
 
+```bash
+# Set environment variables
+export LAMINA_API_KEY=your_key
+export SANITY_PROJECT_ID=your_project
+export SANITY_TOKEN=your_token
+
+# Test CLI
+node dist/cli/index.js apps
+node dist/cli/index.js credits
+
+# Test headless in a script
+node -e "
+  import('sanity-plugin-lamina/headless').then(async ({ createLaminaSanityClient }) => {
+    const client = createLaminaSanityClient({})
+    const apps = await client.lamina.apps.list()
+    console.log(apps.data)
+  })
+"
 ```
-src/
-  index.ts                          # Public exports
-  plugin.tsx                        # definePlugin -- registers all surfaces
-  types.ts                          # Plugin options, generation state types
-  lib/
-    LaminaContext.tsx                # React context + OAuth login flow
-    oauth.ts                        # OAuth token management utilities
-  components/
-    LaminaAssetSource.tsx           # Asset source definition
-    GenerateDialog.tsx              # Generation UI with app picker + multi-select
-    LaminaFieldAction.tsx           # Field-level "Edit in Lamina" button
-  tool/
-    LaminaTool.tsx                  # Studio tool with editor + asset browser tabs
-  actions/
-    regenerateAction.tsx            # Schema-aware document action
-```
+
+---
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,19 @@
 {
   "name": "sanity-plugin-lamina",
-  "version": "0.1.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sanity-plugin-lamina",
-      "version": "0.1.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
+        "@sanity/client": "^6.29.1",
         "@uselamina/sdk": "^0.1.0"
+      },
+      "bin": {
+        "sanity-lamina": "dist/cli/index.js"
       },
       "devDependencies": {
         "@sanity/icons": "^3.5.0",
@@ -25,6 +29,20 @@
         "react": "^18.0.0 || ^19.0.0",
         "sanity": "^3.0.0",
         "styled-components": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sanity/icons": {
+          "optional": true
+        },
+        "@sanity/ui": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "styled-components": {
+          "optional": true
+        }
       }
     },
     "node_modules/@acemir/cssom": {
@@ -4319,7 +4337,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sanity/client": {
+    "node_modules/@sanity/cli/node_modules/@sanity/client": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
       "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
@@ -4333,6 +4351,20 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/client": {
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.29.1.tgz",
+      "integrity": "sha512-BQRCMeDlBxwnMbFtB61HUxFf9aSb4HNVrpfrC7IFVqFf4cwcc3o5H8/nlrL9U3cDFedbe4W0AXt1mQzwbY/ljw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.6.7",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sanity/codegen": {
@@ -4440,7 +4472,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
       "integrity": "sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/event-source-polyfill": "1.0.5",
@@ -4472,21 +4503,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@sanity/export/node_modules/@sanity/client": {
-      "version": "6.29.1",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.29.1.tgz",
-      "integrity": "sha512-BQRCMeDlBxwnMbFtB61HUxFf9aSb4HNVrpfrC7IFVqFf4cwcc3o5H8/nlrL9U3cDFedbe4W0AXt1mQzwbY/ljw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/eventsource": "^5.0.2",
-        "get-it": "^8.6.7",
-        "rxjs": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.18"
       }
     },
     "node_modules/@sanity/export/node_modules/@sanity/types": {
@@ -4829,6 +4845,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sanity/migrate/node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@sanity/mutate": {
       "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.12.6.tgz",
@@ -4847,6 +4879,41 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sanity/mutate/node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/mutate/node_modules/@sanity/client/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/@sanity/mutate/node_modules/nanoid": {
@@ -4896,28 +4963,38 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sanity/preview-url-secret": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.1.16.tgz",
-      "integrity": "sha512-w8N0x8JL4iJ5BZvt9X9pTiXQcSIvBsqtN9rYp7uD5X7JEOgm7heTCxfBYFJUj3Pv5n8Z8W4d872AXZBI5stB6Q==",
+    "node_modules/@sanity/presentation-comlink/node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@sanity/uuid": "3.0.2"
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
       },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/presentation-comlink/node_modules/@sanity/visual-editing-types": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.8.tgz",
+      "integrity": "sha512-4Hu3J8qDLanymnSapRzKwHlQl6SCsBbkL1o5fSMVbWVHvTk/j2uGLLNTsjASICTqUwSm3fwWlyahzCy2uS/LvQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^7.12.0",
-        "@sanity/icons": "*",
-        "sanity": "*"
+        "@sanity/client": "^7.11.2",
+        "@sanity/types": "*"
       },
       "peerDependenciesMeta": {
-        "@sanity/icons": {
-          "optional": true
-        },
-        "sanity": {
+        "@sanity/types": {
           "optional": true
         }
       }
@@ -4956,6 +5033,22 @@
       },
       "engines": {
         "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@sanity/runtime-cli/node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@sanity/runtime-cli/node_modules/chalk": {
@@ -5191,21 +5284,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@sanity/sdk/node_modules/@sanity/client": {
-      "version": "6.29.1",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.29.1.tgz",
-      "integrity": "sha512-BQRCMeDlBxwnMbFtB61HUxFf9aSb4HNVrpfrC7IFVqFf4cwcc3o5H8/nlrL9U3cDFedbe4W0AXt1mQzwbY/ljw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/eventsource": "^5.0.2",
-        "get-it": "^8.6.7",
-        "rxjs": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
     "node_modules/@sanity/telemetry": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@sanity/telemetry/-/telemetry-0.8.1.tgz",
@@ -5257,6 +5335,22 @@
         "@types/react": "18 || 19"
       }
     },
+    "node_modules/@sanity/types/node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@sanity/ui": {
       "version": "2.16.22",
       "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.16.22.tgz",
@@ -5303,6 +5397,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sanity/util/node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@sanity/util/node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -5333,25 +5443,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@sanity/visual-editing-types": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.8.tgz",
-      "integrity": "sha512-4Hu3J8qDLanymnSapRzKwHlQl6SCsBbkL1o5fSMVbWVHvTk/j2uGLLNTsjASICTqUwSm3fwWlyahzCy2uS/LvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@sanity/client": "^7.11.2",
-        "@sanity/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@sanity/types": {
-          "optional": true
-        }
       }
     },
     "node_modules/@sentry-internal/browser-utils": {
@@ -5573,14 +5664,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
       "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/eventsource": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
       "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -7366,7 +7455,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
       "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -8048,7 +8136,6 @@
       "version": "1.0.31",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
       "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/event-target-shim": {
@@ -8085,7 +8172,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8853,7 +8939,6 @@
       "version": "8.7.2",
       "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.7.2.tgz",
       "integrity": "sha512-slSwC/BBAnoz9OnHopU+V5pJKAieddoF6dmx2CvbWMRePgup8ftiB+D7d+pr2PZzcqNtZOVDMoLOsXGsERhTEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "decompress-response": "^7.0.0",
@@ -9598,7 +9683,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/inquirer": {
@@ -9876,7 +9960,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11067,7 +11150,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13227,7 +13309,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -13260,7 +13341,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13442,6 +13522,48 @@
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "styled-components": "^6.1.15"
+      }
+    },
+    "node_modules/sanity/node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/sanity/node_modules/@sanity/preview-url-secret": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.1.16.tgz",
+      "integrity": "sha512-w8N0x8JL4iJ5BZvt9X9pTiXQcSIvBsqtN9rYp7uD5X7JEOgm7heTCxfBYFJUj3Pv5n8Z8W4d872AXZBI5stB6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/uuid": "3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^7.12.0",
+        "@sanity/icons": "*",
+        "sanity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@sanity/icons": {
+          "optional": true
+        },
+        "sanity": {
+          "optional": true
+        }
       }
     },
     "node_modules/sanity/node_modules/react-compiler-runtime": {
@@ -13841,7 +13963,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -14217,7 +14338,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "3"
@@ -14227,7 +14347,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -14434,7 +14553,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel": {
@@ -14451,7 +14569,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -14833,7 +14950,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sanity-plugin-lamina",
   "version": "0.6.0",
-  "description": "Sanity Studio plugin for generating media assets with Lamina",
+  "description": "Sanity plugin for generating media assets with Lamina — Studio UI, headless API, CLI, and webhooks",
   "keywords": [
     "sanity",
     "sanity-plugin",
@@ -10,7 +10,11 @@
     "media-generation",
     "image-generation",
     "video-generation",
-    "asset-source"
+    "asset-source",
+    "headless",
+    "cli",
+    "content-pipeline",
+    "webhook"
   ],
   "homepage": "https://docs.uselamina.ai",
   "repository": {
@@ -25,10 +29,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "sanity-lamina": "./dist/cli/index.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./headless": {
+      "import": "./dist/headless/index.js",
+      "types": "./dist/headless/index.d.ts"
+    },
+    "./webhooks": {
+      "import": "./dist/webhooks/index.js",
+      "types": "./dist/webhooks/index.d.ts"
     }
   },
   "files": [
@@ -42,6 +57,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@sanity/client": "^6.29.1",
     "@uselamina/sdk": "^0.1.0"
   },
   "devDependencies": {
@@ -58,5 +74,19 @@
     "react": "^18.0.0 || ^19.0.0",
     "sanity": "^3.0.0",
     "styled-components": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "@sanity/ui": {
+      "optional": true
+    },
+    "@sanity/icons": {
+      "optional": true
+    },
+    "styled-components": {
+      "optional": true
+    }
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+
+/**
+ * sanity-lamina CLI.
+ *
+ * Programmatic Lamina operations from the terminal.
+ *
+ * Usage:
+ *   npx sanity-lamina generate --query '...' --field heroImage --brief '...'
+ *   npx sanity-lamina fill-document <documentId>
+ *   npx sanity-lamina score
+ *   npx sanity-lamina apps
+ *   npx sanity-lamina credits
+ *
+ * Closes #77.
+ */
+
+import { parseArgs } from 'node:util';
+import { createLaminaSanityClient } from '../headless/client.js';
+import type { FillProgressEvent } from '../headless/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function log(msg: string) {
+  process.stdout.write(`${msg}\n`);
+}
+
+function logProgress(event: FillProgressEvent) {
+  const icon = event.status === 'patched' ? '\u2713'
+    : event.status === 'failed' ? '\u2717'
+      : event.status === 'skipped' ? '-'
+        : '\u2026';
+  const doc = event.documentTitle || event.documentId;
+  log(`  ${icon} ${doc} / ${event.fieldName}: ${event.status}${event.error ? ` (${event.error})` : ''}`);
+}
+
+function die(msg: string): never {
+  process.stderr.write(`Error: ${msg}\n`);
+  process.exit(1);
+}
+
+function printUsage() {
+  log(`
+sanity-lamina — Programmatic media generation with Lamina + Sanity
+
+COMMANDS
+  generate          Bulk generate media for documents matching a GROQ query
+  fill-document     Fill empty media fields on a single document
+  score             Score existing Lamina-generated assets
+  apps              List available Lamina apps
+  credits           Check credit balance
+
+GLOBAL OPTIONS
+  --api-key         Lamina API key         (env: LAMINA_API_KEY)
+  --project         Sanity project ID      (env: SANITY_PROJECT_ID)
+  --dataset         Sanity dataset          (env: SANITY_DATASET, default: production)
+  --token           Sanity API token       (env: SANITY_TOKEN)
+  --json            Output as JSON
+  --help            Show this help
+
+EXAMPLES
+  npx sanity-lamina generate \\
+    --query '*[_type == "product" && !defined(heroImage)]' \\
+    --field heroImage \\
+    --brief 'Product lifestyle photo for {{title}}'
+
+  npx sanity-lamina fill-document product-123 --enhance
+
+  npx sanity-lamina score --limit 50
+`.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Client factory from CLI args
+// ---------------------------------------------------------------------------
+
+interface GlobalOpts {
+  apiKey?: string;
+  project?: string;
+  dataset?: string;
+  token?: string;
+  json?: boolean;
+}
+
+function createClientFromArgs(opts: GlobalOpts) {
+  return createLaminaSanityClient({
+    laminaApiKey: opts.apiKey,
+    sanityProjectId: opts.project,
+    sanityDataset: opts.dataset || undefined,
+    sanityToken: opts.token,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+async function cmdGenerate(args: string[], globalOpts: GlobalOpts) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      query: { type: 'string', short: 'q' },
+      field: { type: 'string', short: 'f' },
+      brief: { type: 'string', short: 'b' },
+      concurrency: { type: 'string', short: 'c' },
+      'brand-profile': { type: 'string' },
+      enhance: { type: 'boolean', default: true },
+      'dry-run': { type: 'boolean', default: false },
+    },
+    strict: false,
+  });
+
+  if (!values.query) die('--query is required. Example: \'*[_type == "product" && !defined(heroImage)]\'');
+  if (!values.field && !values.brief) die('--field or --brief is required');
+
+  const client = createClientFromArgs(globalOpts);
+  const fieldMapping: Record<string, string> = {};
+  if (values.field && values.brief) {
+    fieldMapping[values.field as string] = values.brief as string;
+  }
+
+  log(`Querying documents: ${values.query}`);
+
+  const result = await client.fillEmptyMedia({
+    query: values.query as string,
+    fieldMapping: Object.keys(fieldMapping).length > 0 ? fieldMapping : undefined,
+    concurrency: values.concurrency ? parseInt(values.concurrency as string, 10) : 3,
+    enhance: values.enhance as boolean,
+    brandProfileId: values['brand-profile'] as string | undefined,
+    dryRun: values['dry-run'] as boolean,
+    onProgress: globalOpts.json ? undefined : logProgress,
+  });
+
+  if (globalOpts.json) {
+    log(JSON.stringify(result, null, 2));
+  } else {
+    log('');
+    log(`Done. ${result.documentsProcessed} documents processed.`);
+    log(`  Generated: ${result.fieldsGenerated}`);
+    log(`  Skipped:   ${result.fieldsSkipped}`);
+    log(`  Failed:    ${result.fieldsFailed}`);
+  }
+}
+
+async function cmdFillDocument(args: string[], globalOpts: GlobalOpts) {
+  const documentId = args[0];
+  if (!documentId) die('Document ID is required. Usage: sanity-lamina fill-document <documentId>');
+
+  const { values } = parseArgs({
+    args: args.slice(1),
+    options: {
+      enhance: { type: 'boolean', default: true },
+      'brand-profile': { type: 'string' },
+      concurrency: { type: 'string', short: 'c' },
+    },
+    strict: false,
+  });
+
+  const client = createClientFromArgs(globalOpts);
+
+  log(`Filling empty media for document: ${documentId}`);
+
+  const result = await client.fillEmptyMedia({
+    query: `*[_id == $id || _id == "drafts." + $id]`,
+    queryParams: { id: documentId },
+    concurrency: values.concurrency ? parseInt(values.concurrency as string, 10) : 3,
+    enhance: values.enhance as boolean,
+    brandProfileId: values['brand-profile'] as string | undefined,
+    onProgress: globalOpts.json ? undefined : logProgress,
+  });
+
+  if (globalOpts.json) {
+    log(JSON.stringify(result, null, 2));
+  } else {
+    log('');
+    log(`Done. ${result.fieldsGenerated} generated, ${result.fieldsSkipped} skipped, ${result.fieldsFailed} failed.`);
+  }
+}
+
+async function cmdScore(args: string[], globalOpts: GlobalOpts) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      query: { type: 'string', short: 'q' },
+      limit: { type: 'string', short: 'l' },
+      platform: { type: 'string' },
+    },
+    strict: false,
+  });
+
+  const client = createClientFromArgs(globalOpts);
+
+  log('Scoring Lamina assets...');
+
+  const scores = await client.scoreAssets({
+    query: values.query as string | undefined,
+    limit: values.limit ? parseInt(values.limit as string, 10) : 100,
+    platform: values.platform as string | undefined,
+  });
+
+  if (globalOpts.json) {
+    log(JSON.stringify(scores, null, 2));
+  } else {
+    if (scores.length === 0) {
+      log('No Lamina assets found.');
+      return;
+    }
+    log(`\n${'Asset ID'.padEnd(42)} ${'Score'.padEnd(8)} Brief`);
+    log('-'.repeat(80));
+    for (const s of scores) {
+      const score = s.score !== null ? String(s.score) : 'N/A';
+      const brief = s.brief ? (s.brief.length > 30 ? `${s.brief.substring(0, 30)}...` : s.brief) : '-';
+      log(`${s.assetId.padEnd(42)} ${score.padEnd(8)} ${brief}`);
+    }
+    log(`\n${scores.length} assets scored.`);
+  }
+}
+
+async function cmdApps(_args: string[], globalOpts: GlobalOpts) {
+  const client = createClientFromArgs(globalOpts);
+
+  const result = await client.lamina.apps.list();
+  const apps = result.data ?? [];
+
+  if (globalOpts.json) {
+    log(JSON.stringify(apps, null, 2));
+  } else {
+    if (apps.length === 0) {
+      log('No apps available.');
+      return;
+    }
+    log(`\n${'App ID'.padEnd(30)} ${'Name'.padEnd(25)} Description`);
+    log('-'.repeat(90));
+    for (const app of apps) {
+      const desc = app.description ? (app.description.length > 30 ? `${app.description.substring(0, 30)}...` : app.description) : '-';
+      log(`${app.appId.padEnd(30)} ${app.name.padEnd(25)} ${desc}`);
+    }
+    log(`\n${apps.length} apps available.`);
+  }
+}
+
+async function cmdCredits(_args: string[], globalOpts: GlobalOpts) {
+  const client = createClientFromArgs(globalOpts);
+
+  // Use any app to get credit balance from estimate
+  const appsResult = await client.lamina.apps.list();
+  const firstApp = appsResult.data?.[0];
+
+  if (!firstApp) {
+    log('No apps available to check credits.');
+    return;
+  }
+
+  const estimate = await client.lamina.apps.estimate(firstApp.appId);
+  const data = estimate.data;
+
+  if (globalOpts.json) {
+    log(JSON.stringify(data, null, 2));
+  } else {
+    log(`\nCredit balance: ${data.currentBalance}`);
+    log(`Est. cost per generation (${firstApp.name}): ${data.estimatedCredits.expected} credits`);
+    log(`Affordable: ${data.affordable ? 'Yes' : 'No'}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Parse global flags first
+  const globalFlagIndices = new Set<number>();
+  const globalOpts: GlobalOpts = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--api-key' && args[i + 1]) { globalOpts.apiKey = args[i + 1]; globalFlagIndices.add(i); globalFlagIndices.add(i + 1); i++; }
+    else if (args[i] === '--project' && args[i + 1]) { globalOpts.project = args[i + 1]; globalFlagIndices.add(i); globalFlagIndices.add(i + 1); i++; }
+    else if (args[i] === '--dataset' && args[i + 1]) { globalOpts.dataset = args[i + 1]; globalFlagIndices.add(i); globalFlagIndices.add(i + 1); i++; }
+    else if (args[i] === '--token' && args[i + 1]) { globalOpts.token = args[i + 1]; globalFlagIndices.add(i); globalFlagIndices.add(i + 1); i++; }
+    else if (args[i] === '--json') { globalOpts.json = true; globalFlagIndices.add(i); }
+    else if (args[i] === '--help' || args[i] === '-h') { printUsage(); process.exit(0); }
+  }
+
+  const remaining = args.filter((_, i) => !globalFlagIndices.has(i));
+  const command = remaining[0];
+  const commandArgs = remaining.slice(1);
+
+  if (!command) {
+    printUsage();
+    process.exit(0);
+  }
+
+  try {
+    switch (command) {
+      case 'generate':
+        await cmdGenerate(commandArgs, globalOpts);
+        break;
+      case 'fill-document':
+        await cmdFillDocument(commandArgs, globalOpts);
+        break;
+      case 'score':
+        await cmdScore(commandArgs, globalOpts);
+        break;
+      case 'apps':
+        await cmdApps(commandArgs, globalOpts);
+        break;
+      case 'credits':
+        await cmdCredits(commandArgs, globalOpts);
+        break;
+      default:
+        die(`Unknown command: ${command}. Run 'sanity-lamina --help' for usage.`);
+    }
+  } catch (err) {
+    die(err instanceof Error ? err.message : String(err));
+  }
+}
+
+main();

--- a/src/headless/client.ts
+++ b/src/headless/client.ts
@@ -1,0 +1,662 @@
+/**
+ * Headless Lamina + Sanity client.
+ *
+ * Wraps @uselamina/sdk and @sanity/client into high-level operations
+ * for programmatic content generation at scale — no React required.
+ *
+ * Closes #76.
+ */
+
+import { createClient, type SanityClient } from '@sanity/client';
+import { LaminaClient } from '@uselamina/sdk';
+import type {
+  ExecutionOutput,
+  LaminaCreateParams,
+} from '@uselamina/sdk';
+import { enhanceBrief } from '../lib/briefEnhancer.js';
+import { detectAspectRatio } from '../lib/aspectRatio.js';
+import type {
+  AssetScore,
+  FillEmptyMediaParams,
+  FillEmptyMediaResult,
+  FillProgressEvent,
+  GenerateForDocumentParams,
+  GenerateForDocumentResult,
+  GenerateParams,
+  GeneratedAsset,
+  GenerationResult,
+  LaminaSanityClient,
+  LaminaSanityClientOptions,
+  PredictParams,
+  RecommendationsParams,
+  ScoreAssetsParams,
+  TrendsParams,
+  UploadResult,
+  UploadToSanityParams,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toGeneratedAsset(out: ExecutionOutput): GeneratedAsset | null {
+  if (out.status !== 'completed' || !out.value || typeof out.value !== 'string') {
+    return null;
+  }
+  return {
+    id: out.id,
+    type: out.type,
+    url: out.value,
+    mimeType: out.mimeType ?? null,
+    label: out.label,
+    dimensions: out.dimensions ?? null,
+    durationSeconds: out.durationSeconds ?? null,
+  };
+}
+
+/**
+ * Resolve `{{fieldName}}` placeholders in a brief template against a document.
+ */
+function resolveTemplate(template: string, doc: Record<string, unknown>): string {
+  return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_match, path: string) => {
+    const parts = path.split('.');
+    let current: unknown = doc;
+    for (const part of parts) {
+      if (current == null || typeof current !== 'object') return '';
+      current = (current as Record<string, unknown>)[part];
+    }
+    if (typeof current === 'string') return current;
+    if (typeof current === 'number') return String(current);
+    return '';
+  });
+}
+
+/**
+ * Build a default brief from document context when no explicit brief or template is given.
+ */
+function buildDefaultBrief(
+  fieldName: string,
+  documentType: string,
+  documentTitle: string | null,
+): string {
+  const fieldLabel = fieldName
+    .replace(/([A-Z])/g, ' $1')
+    .toLowerCase()
+    .trim();
+  const parts = [fieldLabel.charAt(0).toUpperCase() + fieldLabel.slice(1)];
+  if (documentTitle) {
+    parts.push(`for ${documentType}: ${documentTitle}`);
+  } else {
+    parts.push(`for ${documentType}`);
+  }
+  return parts.join(' ');
+}
+
+/** Collect image/file field names from a document's _type schema via a GROQ query. */
+async function discoverImageFields(
+  sanity: SanityClient,
+  documentId: string,
+): Promise<string[]> {
+  // Fetch the document and inspect which top-level keys have {asset: {_ref}} shape
+  const doc = await sanity.fetch<Record<string, unknown> | null>(
+    `*[_id == $id || _id == "drafts." + $id][0]`,
+    { id: documentId },
+  );
+  if (!doc) return [];
+
+  const fields: string[] = [];
+  for (const [key, value] of Object.entries(doc)) {
+    if (key.startsWith('_')) continue;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const obj = value as Record<string, unknown>;
+      // An image/file field has _type === 'image' or 'file'
+      if (obj._type === 'image' || obj._type === 'file') {
+        fields.push(key);
+      }
+    }
+  }
+  return fields;
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency helper
+// ---------------------------------------------------------------------------
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let idx = 0;
+
+  async function worker() {
+    while (idx < items.length) {
+      const i = idx++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Client implementation
+// ---------------------------------------------------------------------------
+
+class LaminaSanityClientImpl implements LaminaSanityClient {
+  readonly lamina: LaminaClient;
+  readonly sanity: SanityClient;
+  private readonly opts: LaminaSanityClientOptions;
+
+  constructor(opts: LaminaSanityClientOptions) {
+    this.opts = opts;
+
+    // Resolve Lamina client
+    const laminaApiKey = opts.laminaApiKey || process.env.LAMINA_API_KEY;
+    if (!laminaApiKey) {
+      throw new Error(
+        'sanity-plugin-lamina/headless: laminaApiKey is required. ' +
+        'Pass it via options or set the LAMINA_API_KEY environment variable.',
+      );
+    }
+    this.lamina = new LaminaClient({
+      apiKey: laminaApiKey,
+      baseUrl: opts.laminaBaseUrl,
+    });
+
+    // Resolve Sanity client
+    if (opts.sanityClient) {
+      this.sanity = opts.sanityClient;
+    } else {
+      const projectId = opts.sanityProjectId || process.env.SANITY_PROJECT_ID;
+      const token = opts.sanityToken || process.env.SANITY_TOKEN;
+      if (!projectId) {
+        throw new Error(
+          'sanity-plugin-lamina/headless: sanityProjectId is required. ' +
+          'Pass it via options, provide a sanityClient, or set SANITY_PROJECT_ID.',
+        );
+      }
+      this.sanity = createClient({
+        projectId,
+        dataset: opts.sanityDataset || process.env.SANITY_DATASET || 'production',
+        token,
+        apiVersion: opts.sanityApiVersion || '2024-01-01',
+        useCdn: false,
+      });
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // generate()
+  // -----------------------------------------------------------------------
+
+  async generate(params: GenerateParams): Promise<GenerationResult> {
+    const modality = params.modality || 'image';
+    let finalBrief = params.brief;
+
+    // Enhance brief
+    if (params.enhance !== false) {
+      const enhanced = await enhanceBrief(this.lamina, params.brief, {
+        modality,
+        brandProfileId: params.brandProfileId || this.opts.defaultBrandProfileId,
+        ...(params.metadata?.documentType ? { documentType: params.metadata.documentType } : {}),
+        ...(params.metadata?.documentTitle ? { documentTitle: params.metadata.documentTitle } : {}),
+        ...(params.metadata?.fieldName ? { fieldName: params.metadata.fieldName } : {}),
+      });
+      if (enhanced) finalBrief = enhanced.enhanced;
+    }
+
+    const createParams: LaminaCreateParams & { aspectRatio?: string; metadata?: Record<string, string> } = {
+      brief: finalBrief,
+      modality,
+      ...(params.aspectRatio ? { aspectRatio: params.aspectRatio } : {}),
+      ...(params.appId ? { appId: params.appId } : {}),
+      ...(params.brandProfileId || this.opts.defaultBrandProfileId
+        ? { brandProfileId: params.brandProfileId || this.opts.defaultBrandProfileId }
+        : {}),
+      ...(params.campaignId || this.opts.defaultCampaignId
+        ? { campaignId: params.campaignId || this.opts.defaultCampaignId }
+        : {}),
+      ...(params.inputs ? { inputs: params.inputs } : {}),
+      ...(params.autoQuality ? { autoQuality: params.autoQuality } : {}),
+      ...(this.opts.webhookUrl ? { webhookUrl: this.opts.webhookUrl } : {}),
+      ...(params.metadata ? { metadata: params.metadata } : {}),
+    };
+
+    const createResult = await this.lamina.content.create(createParams);
+    const runId = createResult.data.runId;
+
+    if (!runId) {
+      return {
+        runId: '',
+        status: 'failed',
+        outputs: [],
+        error: 'No run was started. Try a more specific brief.',
+        finalBrief,
+      };
+    }
+
+    const result = await this.lamina.runs.wait(runId, {
+      intervalMs: 3000,
+      timeoutMs: 30 * 60 * 1000,
+    });
+
+    if (result.data.status === 'failed') {
+      return {
+        runId,
+        status: 'failed',
+        outputs: [],
+        error: result.data.errorMessage || 'Generation failed.',
+        finalBrief,
+      };
+    }
+
+    const outputs = result.data.outputs
+      .map(toGeneratedAsset)
+      .filter((o): o is GeneratedAsset => o !== null);
+
+    return {
+      runId,
+      status: 'completed',
+      outputs,
+      error: null,
+      finalBrief,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // generateForDocument()
+  // -----------------------------------------------------------------------
+
+  async generateForDocument(
+    documentId: string,
+    fieldName: string,
+    params?: GenerateForDocumentParams,
+  ): Promise<GenerateForDocumentResult> {
+    // Fetch document for context
+    const doc = await this.sanity.fetch<Record<string, unknown> | null>(
+      `*[_id == $id || _id == "drafts." + $id][0]{ _id, _type, title, name, description, excerpt }`,
+      { id: documentId },
+    );
+
+    const documentType = (doc?._type as string) || 'document';
+    const documentTitle = (doc?.title as string) || (doc?.name as string) || null;
+
+    // Build brief
+    const brief = params?.brief || buildDefaultBrief(fieldName, documentType, documentTitle);
+
+    // Detect aspect ratio from field name
+    const detectedRatio = detectAspectRatio(fieldName);
+
+    const genResult = await this.generate({
+      ...params,
+      brief,
+      aspectRatio: params?.aspectRatio || detectedRatio?.ratio,
+      metadata: {
+        ...params?.metadata,
+        documentType,
+        ...(documentTitle ? { documentTitle } : {}),
+        fieldName,
+        documentId,
+      },
+    });
+
+    if (genResult.status === 'failed' || genResult.outputs.length === 0) {
+      return {
+        ...genResult,
+        sanityAssetId: null,
+        patched: false,
+      };
+    }
+
+    // Upload first output to Sanity and patch the document
+    const output = genResult.outputs[0];
+    try {
+      const uploadResult = await this.uploadToSanity({
+        url: output.url,
+        type: output.type === 'video' ? 'file' : 'image',
+        filename: `lamina-${fieldName}-${output.id}`,
+        source: {
+          name: 'lamina',
+          id: genResult.runId,
+          url: `https://app.uselamina.ai/runs/${genResult.runId}`,
+        },
+        description: genResult.finalBrief,
+        creditLine: 'Generated by Lamina',
+        documentId,
+        fieldName,
+      });
+
+      return {
+        ...genResult,
+        sanityAssetId: uploadResult.assetId,
+        patched: uploadResult.patched,
+      };
+    } catch {
+      return {
+        ...genResult,
+        sanityAssetId: null,
+        patched: false,
+      };
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // fillEmptyMedia()
+  // -----------------------------------------------------------------------
+
+  async fillEmptyMedia(params: FillEmptyMediaParams): Promise<FillEmptyMediaResult> {
+    const concurrency = params.concurrency || 3;
+    const onlyIfEmpty = params.onlyIfEmpty !== false;
+
+    // Fetch documents
+    const docs = await this.sanity.fetch<Array<Record<string, unknown>>>(
+      params.query,
+      params.queryParams || {},
+    );
+
+    if (!docs || docs.length === 0) {
+      return { documentsProcessed: 0, fieldsGenerated: 0, fieldsSkipped: 0, fieldsFailed: 0, results: [] };
+    }
+
+    const result: FillEmptyMediaResult = {
+      documentsProcessed: 0,
+      fieldsGenerated: 0,
+      fieldsSkipped: 0,
+      fieldsFailed: 0,
+      results: [],
+    };
+
+    // Process each document
+    await mapWithConcurrency(docs, concurrency, async (doc, docIdx) => {
+      const documentId = doc._id as string;
+      const documentType = doc._type as string;
+      const documentTitle = (doc.title as string) || (doc.name as string) || null;
+
+      // Discover image/file fields from the document itself
+      const allFields = await discoverImageFields(this.sanity, documentId);
+
+      // Filter to fields from fieldMapping if provided, otherwise use all
+      const targetFields = params.fieldMapping
+        ? Object.keys(params.fieldMapping).filter((f) => allFields.includes(f) || !onlyIfEmpty)
+        : allFields;
+
+      const docResult: FillEmptyMediaResult['results'][0] = {
+        documentId,
+        documentTitle,
+        fields: [],
+      };
+
+      for (const fieldName of targetFields) {
+        // Check if field is empty
+        if (onlyIfEmpty) {
+          const fieldValue = doc[fieldName] as Record<string, unknown> | undefined;
+          const hasAsset = fieldValue?.asset && (fieldValue.asset as Record<string, unknown>)?._ref;
+          if (hasAsset) {
+            docResult.fields.push({
+              fieldName, status: 'skipped', brief: null, assetId: null, error: null,
+            });
+            result.fieldsSkipped++;
+            params.onProgress?.({
+              documentId, documentTitle, fieldName, status: 'skipped', brief: null, error: null,
+              documentsCompleted: docIdx, documentsTotal: docs.length,
+            });
+            continue;
+          }
+        }
+
+        // Build brief
+        let brief: string;
+        if (params.fieldMapping?.[fieldName]) {
+          brief = resolveTemplate(params.fieldMapping[fieldName], doc);
+        } else {
+          brief = buildDefaultBrief(fieldName, documentType, documentTitle);
+        }
+
+        if (params.dryRun) {
+          docResult.fields.push({
+            fieldName, status: 'skipped', brief, assetId: null, error: 'Dry run',
+          });
+          result.fieldsSkipped++;
+          params.onProgress?.({
+            documentId, documentTitle, fieldName, status: 'skipped', brief, error: 'Dry run',
+            documentsCompleted: docIdx, documentsTotal: docs.length,
+          });
+          continue;
+        }
+
+        params.onProgress?.({
+          documentId, documentTitle, fieldName, status: 'generating', brief, error: null,
+          documentsCompleted: docIdx, documentsTotal: docs.length,
+        });
+
+        try {
+          const genResult = await this.generateForDocument(documentId, fieldName, {
+            brief,
+            enhance: params.enhance,
+            brandProfileId: params.brandProfileId,
+          });
+
+          if (genResult.status === 'completed' && genResult.patched) {
+            docResult.fields.push({
+              fieldName, status: 'generated', brief: genResult.finalBrief,
+              assetId: genResult.sanityAssetId, error: null,
+            });
+            result.fieldsGenerated++;
+            params.onProgress?.({
+              documentId, documentTitle, fieldName, status: 'patched',
+              brief: genResult.finalBrief, error: null,
+              documentsCompleted: docIdx, documentsTotal: docs.length,
+            });
+          } else {
+            docResult.fields.push({
+              fieldName, status: 'failed', brief, assetId: null,
+              error: genResult.error || 'Generation failed',
+            });
+            result.fieldsFailed++;
+            params.onProgress?.({
+              documentId, documentTitle, fieldName, status: 'failed',
+              brief, error: genResult.error || 'Generation failed',
+              documentsCompleted: docIdx, documentsTotal: docs.length,
+            });
+          }
+        } catch (err) {
+          const error = err instanceof Error ? err.message : 'Unknown error';
+          docResult.fields.push({ fieldName, status: 'failed', brief, assetId: null, error });
+          result.fieldsFailed++;
+          params.onProgress?.({
+            documentId, documentTitle, fieldName, status: 'failed', brief, error,
+            documentsCompleted: docIdx, documentsTotal: docs.length,
+          });
+        }
+      }
+
+      result.results.push(docResult);
+      result.documentsProcessed++;
+    });
+
+    return result;
+  }
+
+  // -----------------------------------------------------------------------
+  // uploadToSanity()
+  // -----------------------------------------------------------------------
+
+  async uploadToSanity(params: UploadToSanityParams): Promise<UploadResult> {
+    const assetType = params.type || 'image';
+
+    // Transfer through Lamina CDN for CORS safety
+    let cdnUrl = params.url;
+    try {
+      const transfer = await this.lamina.publishing.transferAsset({
+        sourceUrl: params.url,
+        mediaType: assetType === 'file' ? 'video' : 'image',
+        filename: params.filename,
+      });
+      cdnUrl = transfer.data.cdnUrl;
+    } catch {
+      // Fall back to direct URL
+    }
+
+    // Fetch and upload to Sanity
+    const response = await fetch(cdnUrl);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const contentType = response.headers.get('content-type') || (assetType === 'file' ? 'video/mp4' : 'image/png');
+    const extension = contentType.split('/')[1] || 'png';
+    const filename = params.filename || `lamina-asset.${extension}`;
+
+    const asset = await this.sanity.assets.upload(assetType, buffer, {
+      filename: filename.includes('.') ? filename : `${filename}.${extension}`,
+      contentType,
+      source: params.source || { name: 'lamina', id: 'headless' },
+      description: params.description,
+      creditLine: params.creditLine || 'Generated by Lamina',
+    });
+
+    let patched = false;
+
+    // Patch document if requested
+    if (params.documentId && params.fieldName) {
+      try {
+        const fieldType = assetType === 'file' ? 'file' : 'image';
+        await this.sanity
+          .patch(params.documentId)
+          .set({
+            [params.fieldName]: {
+              _type: fieldType,
+              asset: { _type: 'reference', _ref: asset._id },
+            },
+          })
+          .commit();
+        patched = true;
+      } catch {
+        // Patch failed — asset was still uploaded
+      }
+    }
+
+    return {
+      assetId: asset._id,
+      url: asset.url,
+      patched,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // scoreAssets()
+  // -----------------------------------------------------------------------
+
+  async scoreAssets(params?: ScoreAssetsParams): Promise<AssetScore[]> {
+    const query = params?.query
+      || `*[_type in ["sanity.imageAsset", "sanity.fileAsset"] && source.name == "lamina"][0..${(params?.limit || 100) - 1}]{ _id, url, description }`;
+
+    const assets = await this.sanity.fetch<Array<{ _id: string; url: string; description: string | null }>>(query);
+    if (!assets || assets.length === 0) return [];
+
+    // Score via the Lamina content.score API
+    try {
+      const result = await this.lamina.content.score({
+        contentItemIds: assets.map((a) => a._id),
+        ...(params?.platform ? { platform: params.platform } : {}),
+        ...(params?.modality ? { modality: params.modality } : {}),
+        limit: params?.limit || 100,
+      });
+
+      const scoreMap = new Map<string, number>();
+      const scores = (result.data as Record<string, unknown>)?.scores as Array<{ id: string; score: number }> | undefined;
+      if (Array.isArray(scores)) {
+        for (const s of scores) {
+          scoreMap.set(s.id, s.score);
+        }
+      }
+
+      return assets.map((a) => ({
+        assetId: a._id,
+        url: a.url,
+        score: scoreMap.get(a._id) ?? null,
+        brief: a.description,
+      }));
+    } catch {
+      // Scoring not available — return assets without scores
+      return assets.map((a) => ({
+        assetId: a._id,
+        url: a.url,
+        score: null,
+        brief: a.description,
+      }));
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // intelligence
+  // -----------------------------------------------------------------------
+
+  readonly intelligence = {
+    trends: async (params?: TrendsParams) => {
+      const result = await this.lamina.intelligence.trends(params);
+      return result.data;
+    },
+
+    predict: async (params: PredictParams) => {
+      const result = await this.lamina.intelligence.predict({
+        concept: params.concept,
+        platform: params.platform,
+        modality: params.modality || 'image',
+        brandProfileId: params.brandProfileId || this.opts.defaultBrandProfileId,
+        campaignId: params.campaignId || this.opts.defaultCampaignId,
+      });
+      return result.data;
+    },
+
+    recommendations: async (params?: RecommendationsParams) => {
+      const result = await this.lamina.intelligence.recommendations(params);
+      return result.data;
+    },
+
+    getBrandContext: async (brandProfileId?: string) => {
+      const result = await this.lamina.intelligence.getBrandContext({
+        brandProfileId: brandProfileId || this.opts.defaultBrandProfileId,
+      });
+      return result.data;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a headless Lamina + Sanity client for programmatic content generation.
+ *
+ * @example
+ * ```ts
+ * import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'
+ *
+ * const lamina = createLaminaSanityClient({
+ *   laminaApiKey: process.env.LAMINA_API_KEY,
+ *   sanityProjectId: 'abc123',
+ *   sanityDataset: 'production',
+ *   sanityToken: process.env.SANITY_TOKEN,
+ * })
+ *
+ * // Generate + upload + patch in one call
+ * await lamina.generateForDocument('product-123', 'heroImage', {
+ *   brief: 'Lifestyle product photo',
+ * })
+ *
+ * // Bulk: find empty fields, generate, patch
+ * await lamina.fillEmptyMedia({
+ *   query: '*[_type == "product" && !defined(mainImage)]',
+ *   fieldMapping: { mainImage: 'Product photo: {{title}}' },
+ *   concurrency: 5,
+ * })
+ * ```
+ */
+export function createLaminaSanityClient(
+  options: LaminaSanityClientOptions,
+): LaminaSanityClient {
+  return new LaminaSanityClientImpl(options);
+}

--- a/src/headless/index.ts
+++ b/src/headless/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Headless entry point for sanity-plugin-lamina.
+ *
+ * Import from 'sanity-plugin-lamina/headless' — no React or browser required.
+ *
+ * @example
+ * ```ts
+ * import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'
+ *
+ * const lamina = createLaminaSanityClient({
+ *   laminaApiKey: process.env.LAMINA_API_KEY,
+ *   sanityProjectId: 'abc123',
+ *   sanityToken: process.env.SANITY_TOKEN,
+ * })
+ *
+ * await lamina.generateForDocument('product-123', 'heroImage', {
+ *   brief: 'Lifestyle product photo',
+ * })
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { createLaminaSanityClient } from './client.js';
+
+export type {
+  AssetScore,
+  FillEmptyMediaParams,
+  FillEmptyMediaResult,
+  FillProgressEvent,
+  GenerateForDocumentParams,
+  GenerateForDocumentResult,
+  GenerateParams,
+  GeneratedAsset,
+  GenerationResult,
+  LaminaSanityClient,
+  LaminaSanityClientOptions,
+  PredictParams,
+  RecommendationsParams,
+  ScoreAssetsParams,
+  TrendsParams,
+  UploadResult,
+  UploadToSanityParams,
+} from './types.js';

--- a/src/headless/types.ts
+++ b/src/headless/types.ts
@@ -1,0 +1,302 @@
+/**
+ * Types for the headless API layer.
+ *
+ * These types define the programmatic interface for using Lamina
+ * with Sanity outside of the Studio UI — in scripts, pipelines,
+ * serverless functions, and CLI tools.
+ */
+
+import type { SanityClient } from '@sanity/client';
+import type { LaminaAspectRatio } from '../lib/aspectRatio.js';
+
+// ---------------------------------------------------------------------------
+// Client options
+// ---------------------------------------------------------------------------
+
+export interface LaminaSanityClientOptions {
+  /** Lamina API key. Falls back to LAMINA_API_KEY env var. */
+  laminaApiKey?: string;
+  /** Lamina API base URL. Defaults to https://app.uselamina.ai */
+  laminaBaseUrl?: string;
+
+  /**
+   * A pre-configured @sanity/client instance.
+   * If provided, sanityProjectId / sanityDataset / sanityToken are ignored.
+   */
+  sanityClient?: SanityClient;
+
+  /** Sanity project ID. Required if sanityClient is not provided. */
+  sanityProjectId?: string;
+  /** Sanity dataset. Defaults to 'production'. */
+  sanityDataset?: string;
+  /** Sanity API token with write access. Falls back to SANITY_TOKEN env var. */
+  sanityToken?: string;
+  /** Sanity API version. Defaults to '2024-01-01'. */
+  sanityApiVersion?: string;
+
+  /** Default brand profile ID for all generations. */
+  defaultBrandProfileId?: string;
+  /** Default campaign ID for all generations. */
+  defaultCampaignId?: string;
+  /** Webhook URL passed to Lamina for completion notifications. */
+  webhookUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+export interface GenerateParams {
+  /** The generation brief / prompt. */
+  brief: string;
+  /** Output modality. Defaults to 'image'. */
+  modality?: 'image' | 'video';
+  /** Aspect ratio hint. */
+  aspectRatio?: LaminaAspectRatio;
+  /** Pin a specific Lamina app. */
+  appId?: string;
+  /** Brand profile ID (overrides client default). */
+  brandProfileId?: string;
+  /** Campaign ID (overrides client default). */
+  campaignId?: string;
+  /** Additional inputs for the selected app. */
+  inputs?: Record<string, unknown>;
+  /** Whether to auto-enhance the brief before generation. Defaults to true. */
+  enhance?: boolean;
+  /** Auto-quality control. */
+  autoQuality?: { enabled: boolean; minScore?: number; maxRetries?: number };
+  /** Metadata to attach to the generation request. */
+  metadata?: Record<string, string>;
+}
+
+export interface GeneratedAsset {
+  id: string;
+  type: 'image' | 'video' | 'text' | string;
+  url: string;
+  mimeType: string | null;
+  label: string;
+  dimensions: { width: number; height: number } | null;
+  durationSeconds: number | null;
+}
+
+export interface GenerationResult {
+  runId: string;
+  status: 'completed' | 'failed';
+  outputs: GeneratedAsset[];
+  error: string | null;
+  /** The (possibly enhanced) brief that was actually sent to the API. */
+  finalBrief: string;
+}
+
+// ---------------------------------------------------------------------------
+// Document operations
+// ---------------------------------------------------------------------------
+
+export interface GenerateForDocumentParams extends Omit<GenerateParams, 'brief'> {
+  /** Override the auto-generated brief. If omitted, built from document context. */
+  brief?: string;
+}
+
+export interface GenerateForDocumentResult extends GenerationResult {
+  /** The Sanity asset document ID after upload. Null if upload failed or was skipped. */
+  sanityAssetId: string | null;
+  /** Whether the document was patched with the new asset. */
+  patched: boolean;
+}
+
+export interface FillEmptyMediaParams {
+  /** GROQ query that returns documents to process. Must return _id and _type. */
+  query: string;
+  /** GROQ query params. */
+  queryParams?: Record<string, unknown>;
+  /**
+   * Mapping of field names to brief templates.
+   * Templates support {{fieldName}} placeholders resolved from the document.
+   * If omitted, briefs are auto-generated from field names and document context.
+   */
+  fieldMapping?: Record<string, string>;
+  /** Only generate for fields that are currently empty. Defaults to true. */
+  onlyIfEmpty?: boolean;
+  /** Max concurrent generations. Defaults to 3. */
+  concurrency?: number;
+  /** Whether to auto-enhance briefs. Defaults to true. */
+  enhance?: boolean;
+  /** Brand profile ID for all generations. */
+  brandProfileId?: string;
+  /** Called after each field is processed. */
+  onProgress?: (event: FillProgressEvent) => void;
+  /** If true, don't actually generate or patch — just report what would happen. */
+  dryRun?: boolean;
+}
+
+export interface FillProgressEvent {
+  documentId: string;
+  documentTitle: string | null;
+  fieldName: string;
+  status: 'generating' | 'uploading' | 'patched' | 'skipped' | 'failed';
+  brief: string | null;
+  error: string | null;
+  /** Progress: documents completed / total documents. */
+  documentsCompleted: number;
+  documentsTotal: number;
+}
+
+export interface FillEmptyMediaResult {
+  /** Total documents processed. */
+  documentsProcessed: number;
+  /** Total fields generated. */
+  fieldsGenerated: number;
+  /** Total fields skipped (already filled or failed). */
+  fieldsSkipped: number;
+  /** Total fields that failed. */
+  fieldsFailed: number;
+  /** Per-document results. */
+  results: Array<{
+    documentId: string;
+    documentTitle: string | null;
+    fields: Array<{
+      fieldName: string;
+      status: 'generated' | 'skipped' | 'failed';
+      brief: string | null;
+      assetId: string | null;
+      error: string | null;
+    }>;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Asset operations
+// ---------------------------------------------------------------------------
+
+export interface UploadToSanityParams {
+  /** URL of the asset to upload. */
+  url: string;
+  /** Asset type. Defaults to 'image'. */
+  type?: 'image' | 'file';
+  /** Filename for the uploaded asset. */
+  filename?: string;
+  /** Source metadata. */
+  source?: {
+    name: string;
+    id: string;
+    url?: string;
+  };
+  /** Description stored on the asset document. */
+  description?: string;
+  /** Credit line. */
+  creditLine?: string;
+  /** Document ID to associate the asset with (stored in source metadata). */
+  documentId?: string;
+  /** Field name to patch on the document after upload. */
+  fieldName?: string;
+}
+
+export interface UploadResult {
+  assetId: string;
+  url: string;
+  patched: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+export interface ScoreAssetsParams {
+  /** GROQ query returning asset documents. */
+  query?: string;
+  /** Limit. Defaults to 100. */
+  limit?: number;
+  /** Platform context. */
+  platform?: string;
+  /** Modality context. */
+  modality?: string;
+}
+
+export interface AssetScore {
+  assetId: string;
+  url: string;
+  score: number | null;
+  brief: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Intelligence
+// ---------------------------------------------------------------------------
+
+export interface TrendsParams {
+  category?: string;
+  platform?: string;
+  windowDays?: number;
+  limit?: number;
+}
+
+export interface PredictParams {
+  /** The content concept string to predict performance for. */
+  concept: string;
+  /** Target platform (e.g. 'instagram', 'twitter'). */
+  platform: string;
+  /** Modality (e.g. 'image', 'video'). Defaults to 'image'. */
+  modality?: string;
+  brandProfileId?: string;
+  campaignId?: string;
+}
+
+export interface RecommendationsParams {
+  campaignId?: string;
+  workflowId?: string;
+  brandProfileId?: string;
+  platform?: string;
+  objective?: string;
+  modality?: string;
+  limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// The client interface
+// ---------------------------------------------------------------------------
+
+export interface LaminaSanityClient {
+  /** The underlying Lamina SDK client. */
+  readonly lamina: import('@uselamina/sdk').LaminaClient;
+  /** The underlying Sanity client. */
+  readonly sanity: SanityClient;
+
+  /**
+   * Generate content and return outputs without uploading to Sanity.
+   */
+  generate(params: GenerateParams): Promise<GenerationResult>;
+
+  /**
+   * Generate content for a specific document field.
+   * Uploads the first output to Sanity and patches the document.
+   */
+  generateForDocument(
+    documentId: string,
+    fieldName: string,
+    params?: GenerateForDocumentParams,
+  ): Promise<GenerateForDocumentResult>;
+
+  /**
+   * Find documents matching a GROQ query and fill their empty media fields.
+   * The workhorse for bulk content generation.
+   */
+  fillEmptyMedia(params: FillEmptyMediaParams): Promise<FillEmptyMediaResult>;
+
+  /**
+   * Upload an asset URL to Sanity and optionally patch a document field.
+   */
+  uploadToSanity(params: UploadToSanityParams): Promise<UploadResult>;
+
+  /**
+   * Score existing Lamina-generated assets.
+   */
+  scoreAssets(params?: ScoreAssetsParams): Promise<AssetScore[]>;
+
+  /** Intelligence sub-client. */
+  readonly intelligence: {
+    trends(params?: TrendsParams): Promise<unknown>;
+    predict(params: PredictParams): Promise<unknown>;
+    recommendations(params?: RecommendationsParams): Promise<unknown>;
+    getBrandContext(brandProfileId?: string): Promise<unknown>;
+  };
+}

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,0 +1,245 @@
+/**
+ * Webhook handler factory for auto-generating media on Sanity document events.
+ *
+ * Deploy as a Vercel / Netlify / Cloudflare serverless function.
+ * Listens for Sanity GROQ-powered webhook payloads and triggers Lamina
+ * generation for matching documents.
+ *
+ * Import from 'sanity-plugin-lamina/webhooks'.
+ *
+ * @example
+ * ```ts
+ * import { createLaminaWebhookHandler } from 'sanity-plugin-lamina/webhooks'
+ *
+ * export default createLaminaWebhookHandler({
+ *   laminaApiKey: process.env.LAMINA_API_KEY,
+ *   sanityProjectId: 'abc123',
+ *   sanityToken: process.env.SANITY_TOKEN,
+ *   sanityWebhookSecret: process.env.SANITY_WEBHOOK_SECRET,
+ *   triggers: [
+ *     {
+ *       filter: '_type == "product"',
+ *       fields: {
+ *         heroImage: 'Product photo for {{title}}',
+ *         thumbnail: 'Product thumbnail, {{title}}',
+ *       },
+ *       onlyIfEmpty: true,
+ *     },
+ *   ],
+ * })
+ * ```
+ *
+ * Closes #78.
+ *
+ * @packageDocumentation
+ */
+
+import { createLaminaSanityClient } from '../headless/client.js';
+import type { LaminaSanityClientOptions, FillProgressEvent } from '../headless/types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WebhookTrigger {
+  /**
+   * GROQ filter expression to match documents.
+   * Evaluated against the webhook payload's document.
+   * @example '_type == "product"'
+   */
+  filter: string;
+  /**
+   * Field-to-brief mapping.
+   * Keys are field names. Values are brief templates with {{fieldName}} placeholders.
+   */
+  fields: Record<string, string>;
+  /** Only generate if the field is currently empty. Defaults to true. */
+  onlyIfEmpty?: boolean;
+  /** Whether to enhance briefs before generation. Defaults to true. */
+  enhance?: boolean;
+  /** Brand profile ID for this trigger. */
+  brandProfileId?: string;
+  /** Campaign ID for this trigger. */
+  campaignId?: string;
+}
+
+export interface WebhookHandlerOptions extends LaminaSanityClientOptions {
+  /** Secret for verifying Sanity webhook signatures. */
+  sanityWebhookSecret?: string;
+  /** Trigger configurations. */
+  triggers: WebhookTrigger[];
+  /** Called after each field is generated. */
+  onGenerated?: (documentId: string, fieldName: string, assetId: string) => void;
+  /** Called when a field generation fails. */
+  onError?: (documentId: string, fieldName: string, error: string) => void;
+  /** Called for every progress event. */
+  onProgress?: (event: FillProgressEvent) => void;
+}
+
+/** Sanity webhook payload shape (GROQ-powered webhooks). */
+interface SanityWebhookPayload {
+  _id: string;
+  _type: string;
+  _rev?: string;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+async function verifySanitySignature(
+  body: string,
+  signature: string | null,
+  secret: string,
+): Promise<boolean> {
+  if (!signature) return false;
+  try {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      'raw',
+      encoder.encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    );
+    const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+    const expected = Array.from(new Uint8Array(sig))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    return expected === signature;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Evaluate a simple GROQ-like filter against a document.
+ * Supports: _type == "value", _type in ["a", "b"], and simple && / || combinators.
+ * For complex filters, the caller should configure Sanity webhooks with GROQ filters
+ * server-side and skip client-side filtering.
+ */
+function matchesFilter(doc: SanityWebhookPayload, filter: string): boolean {
+  // _type == "value"
+  const typeMatch = filter.match(/_type\s*==\s*"([^"]+)"/);
+  if (typeMatch) {
+    return doc._type === typeMatch[1];
+  }
+  // _type in ["a", "b"]
+  const inMatch = filter.match(/_type\s+in\s+\[([^\]]+)\]/);
+  if (inMatch) {
+    const values = inMatch[1].match(/"([^"]+)"/g)?.map((v) => v.replace(/"/g, ''));
+    return values ? values.includes(doc._type) : false;
+  }
+  // Fallback: match all
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a webhook handler that auto-generates Lamina assets when
+ * Sanity documents are created or updated.
+ *
+ * Returns a standard `(request: Request) => Promise<Response>` handler
+ * compatible with Vercel, Netlify, Cloudflare Workers, and Express
+ * (via adapter).
+ */
+export function createLaminaWebhookHandler(
+  opts: WebhookHandlerOptions,
+): (request: Request) => Promise<Response> {
+  const client = createLaminaSanityClient(opts);
+
+  return async (request: Request): Promise<Response> => {
+    // Only accept POST
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+
+    const body = await request.text();
+
+    // Verify signature if secret is configured
+    if (opts.sanityWebhookSecret) {
+      const signature = request.headers.get('sanity-webhook-signature');
+      const valid = await verifySanitySignature(body, signature, opts.sanityWebhookSecret);
+      if (!valid) {
+        return new Response('Invalid signature', { status: 401 });
+      }
+    }
+
+    let payload: SanityWebhookPayload;
+    try {
+      payload = JSON.parse(body) as SanityWebhookPayload;
+    } catch {
+      return new Response('Invalid JSON', { status: 400 });
+    }
+
+    if (!payload._id || !payload._type) {
+      return new Response('Missing _id or _type', { status: 400 });
+    }
+
+    // Find matching triggers
+    const matchingTriggers = opts.triggers.filter((t) => matchesFilter(payload, t.filter));
+    if (matchingTriggers.length === 0) {
+      return new Response(JSON.stringify({ status: 'skipped', reason: 'No matching triggers' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    // Merge all field mappings from matching triggers
+    const fieldMapping: Record<string, string> = {};
+    let enhance = true;
+    let brandProfileId: string | undefined;
+
+    for (const trigger of matchingTriggers) {
+      Object.assign(fieldMapping, trigger.fields);
+      if (trigger.enhance === false) enhance = false;
+      if (trigger.brandProfileId) brandProfileId = trigger.brandProfileId;
+    }
+
+    const onlyIfEmpty = matchingTriggers.every((t) => t.onlyIfEmpty !== false);
+
+    // Run generation
+    try {
+      const result = await client.fillEmptyMedia({
+        query: `*[_id == $id][0]`,
+        queryParams: { id: payload._id },
+        fieldMapping,
+        onlyIfEmpty,
+        enhance,
+        brandProfileId,
+        concurrency: 2,
+        onProgress: (event) => {
+          opts.onProgress?.(event);
+          if (event.status === 'patched') {
+            opts.onGenerated?.(event.documentId, event.fieldName, '');
+          }
+          if (event.status === 'failed' && event.error) {
+            opts.onError?.(event.documentId, event.fieldName, event.error);
+          }
+        },
+      });
+
+      return new Response(JSON.stringify({
+        status: 'completed',
+        documentId: payload._id,
+        fieldsGenerated: result.fieldsGenerated,
+        fieldsFailed: result.fieldsFailed,
+        fieldsSkipped: result.fieldsSkipped,
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : 'Unknown error';
+      opts.onError?.(payload._id, '*', error);
+      return new Response(JSON.stringify({ status: 'error', error }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Adds three new entry points that make the plugin useful beyond the Studio UI — for scripts, CI pipelines, content migrations, and serverless automation.

- **Headless API** (`sanity-plugin-lamina/headless`, #76): `createLaminaSanityClient()` wraps both SDKs into high-level operations: `generate()`, `generateForDocument()`, `fillEmptyMedia()`, `uploadToSanity()`, `scoreAssets()`, and intelligence APIs
- **Webhook handler** (`sanity-plugin-lamina/webhooks`, #78): `createLaminaWebhookHandler()` for auto-generating media on Sanity document events — deploy as a serverless function
- **CLI** (`npx sanity-lamina`, #77): 5 commands — `generate`, `fill-document`, `score`, `apps`, `credits` — with `--json`, `--dry-run`, and env var config
- **Comprehensive docs** (#79): Full README rewrite covering all 4 surfaces with recipes for migrations, CI pipelines, multi-brand generation, and quality gates

### New files
| Path | Purpose |
|------|---------|
| `src/headless/index.ts` | Headless entry point |
| `src/headless/client.ts` | `createLaminaSanityClient()` — 660 lines, full implementation |
| `src/headless/types.ts` | All headless types (params, results, client interface) |
| `src/webhooks/index.ts` | `createLaminaWebhookHandler()` with trigger matching + signature verification |
| `src/cli/index.ts` | CLI with 5 commands, global flags, --json output |

### Package changes
| Change | Detail |
|--------|--------|
| New exports | `./headless`, `./webhooks` |
| New bin | `sanity-lamina` |
| New dependency | `@sanity/client` (direct, for headless usage without full `sanity` package) |
| peerDependenciesMeta | `react`, `@sanity/ui`, `@sanity/icons`, `styled-components` marked optional |
| README | Comprehensive rewrite — Studio, headless, CLI, webhooks, recipes, architecture |
| CLAUDE.md | Updated architecture section |

## Test plan

- [ ] `npm run build` — clean compile with all new entry points
- [ ] Verify `dist/headless/index.js`, `dist/webhooks/index.js`, `dist/cli/index.js` exist
- [ ] `node dist/cli/index.js --help` — prints usage
- [ ] Import test: `import { createLaminaSanityClient } from 'sanity-plugin-lamina/headless'` resolves
- [ ] Import test: `import { createLaminaWebhookHandler } from 'sanity-plugin-lamina/webhooks'` resolves
- [ ] Headless client creation with env vars succeeds
- [ ] CLI `apps` command lists available Lamina apps
- [ ] CLI `credits` command shows balance
- [ ] Webhook handler returns 405 for non-POST
- [ ] Webhook handler returns 401 for bad signature when secret is set
- [ ] Existing Studio plugin still works (no regressions from peerDependenciesMeta change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)